### PR TITLE
feat: (#6) 밋업, 기업 프로젝트 리스트 정렬 기능을 추가한다

### DIFF
--- a/src/main/java/com/kusitms/website/domain/project/CorporateRepository.java
+++ b/src/main/java/com/kusitms/website/domain/project/CorporateRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface CorporateRepository extends JpaRepository<CorporateProject, Long> {
     List<CorporateProject> findAllByOrderByCardinalDesc();
+    List<CorporateProject> findAllByOrderByCardinalAsc();
 }

--- a/src/main/java/com/kusitms/website/domain/project/MeetupRepository.java
+++ b/src/main/java/com/kusitms/website/domain/project/MeetupRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface MeetupRepository extends JpaRepository<MeetupProject, Long> {
-    List<MeetupProject> findAllByOrderByCardinalDesc();
+    List<MeetupProject> findAllByOrderByCardinalDesc(); // 최신순
+    List<MeetupProject> findAllByOrderByCardinalAsc();  // 오래된 순
 }

--- a/src/main/java/com/kusitms/website/domain/project/ProjectController.java
+++ b/src/main/java/com/kusitms/website/domain/project/ProjectController.java
@@ -57,7 +57,7 @@ public class ProjectController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = CorporateDetailResponse.class)))
     })
-    public ResponseEntity<BaseResponse> getCorporateProjects() {
-        return ResponseEntity.ok(new BaseResponse(corporateService.getCorporateProjects()));
+    public ResponseEntity<BaseResponse> getCorporateProjects(@RequestParam(defaultValue = "desc") String order) {
+        return ResponseEntity.ok(new BaseResponse(corporateService.getCorporateProjects(order)));
     }
 }

--- a/src/main/java/com/kusitms/website/domain/project/ProjectController.java
+++ b/src/main/java/com/kusitms/website/domain/project/ProjectController.java
@@ -33,8 +33,8 @@ public class ProjectController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = MeetupDetailResponse.class)))
     })
-    public ResponseEntity<BaseResponse> getMeetupProjects() {
-        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects()));
+    public ResponseEntity<BaseResponse> getMeetupProjects(@RequestParam(defaultValue = "desc") String order) {
+        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects(order)));
     }
 
     @GetMapping("/meetup/{meetup_id}")

--- a/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
@@ -13,10 +13,10 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CorporateService {
     private final CorporateRepository corporateRepository;
 
-    @Transactional(readOnly = true)
     public CorporateResponse getCorporateProjects() {
         List<CorporateProject> findProjects = corporateRepository.findAllByOrderByCardinalDesc();
 

--- a/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
@@ -17,8 +17,13 @@ import java.util.stream.Collectors;
 public class CorporateService {
     private final CorporateRepository corporateRepository;
 
-    public CorporateResponse getCorporateProjects() {
-        List<CorporateProject> findProjects = corporateRepository.findAllByOrderByCardinalDesc();
+    public CorporateResponse getCorporateProjects(String order) {
+        List<CorporateProject> findProjects;
+        if ("asc".equals(order)) {
+            findProjects = corporateRepository.findAllByOrderByCardinalAsc();  // 오래된 순
+        } else {
+            findProjects = corporateRepository.findAllByOrderByCardinalDesc();  // 최신순
+        }
 
         List<CorporateDetailResponse> detailResponses = findProjects.stream()
                 .map(p -> new CorporateDetailResponse(p))

--- a/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
@@ -15,12 +15,13 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MeetupService {
     private final S3Service s3Service;
     private final MeetupRepository meetupRepository;
     private final MeetupTeamRepository meetupTeamRepository;
 
-    @Transactional(readOnly = true)
+
     public MeetupResponse getMeetupProjects() {
         List<MeetupProject> findProjects = meetupRepository.findAllByOrderByCardinalDesc();
 
@@ -34,7 +35,7 @@ public class MeetupService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
+
     public MeetupDetailResponse getMeetupProject(Long meetupId) {
         MeetupProject findProject = meetupRepository.findById(meetupId).orElseThrow();
 

--- a/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
@@ -22,8 +22,13 @@ public class MeetupService {
     private final MeetupTeamRepository meetupTeamRepository;
 
 
-    public MeetupResponse getMeetupProjects() {
-        List<MeetupProject> findProjects = meetupRepository.findAllByOrderByCardinalDesc();
+    public MeetupResponse getMeetupProjects(String order) {
+        List<MeetupProject> findProjects;
+        if ("asc".equals(order)) {
+            findProjects = meetupRepository.findAllByOrderByCardinalAsc();  // 오래된 순
+        } else {
+            findProjects = meetupRepository.findAllByOrderByCardinalDesc();  // 최신순
+        }
 
         List<MeetupDetailResponse> meetupDetailResponses = findProjects.stream()
                 .map(p -> new MeetupDetailResponse(p, false))


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #6   

## 💡 작업 내용
- order 파라미터 값으로 asc(오래된 순) 또는 desc(최신순)를 받고, 해당 값에 정렬한 리스트를 반환한다.
- 기본적으로 order 파라미터가 없으면 최신순(desc)으로 처리된다.

## 📸 스크린샷(선택)

## 🎸 기타
GET api/projects/meetup?order=desc (최신순)  
GET api/projects/meetup?order=asc (오래된 순)
GET api/projects/corporate?order=desc (최신순)  
GET api/projects/corporate?order=asc (오래된 순)