### PR TITLE
refactor: (#12) 밋업/기업 프로젝트를 기수 단위로 조회한다

### DIFF
--- a/src/main/java/com/kusitms/website/domain/project/CorporateRepository.java
+++ b/src/main/java/com/kusitms/website/domain/project/CorporateRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface CorporateRepository extends JpaRepository<CorporateProject, Long> {
     List<CorporateProject> findAllByOrderByCardinalDesc();
     List<CorporateProject> findAllByOrderByCardinalAsc();
+    List<CorporateProject> findAllByCardinal(Integer cardinal);
 }

--- a/src/main/java/com/kusitms/website/domain/project/MeetupRepository.java
+++ b/src/main/java/com/kusitms/website/domain/project/MeetupRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface MeetupRepository extends JpaRepository<MeetupProject, Long> {
     List<MeetupProject> findAllByOrderByCardinalDesc(); // 최신순
     List<MeetupProject> findAllByOrderByCardinalAsc();  // 오래된 순
+    List<MeetupProject> findAllByCardinal(Integer cardinal);
 }

--- a/src/main/java/com/kusitms/website/domain/project/ProjectController.java
+++ b/src/main/java/com/kusitms/website/domain/project/ProjectController.java
@@ -59,7 +59,9 @@ public class ProjectController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = CorporateDetailResponse.class)))
     })
-    public ResponseEntity<BaseResponse> getCorporateProjects(@RequestParam(defaultValue = "desc") String order) {
-        return ResponseEntity.ok(new BaseResponse(corporateService.getCorporateProjects(order)));
+    public ResponseEntity<BaseResponse> getCorporateProjects(
+            @RequestParam(required = false) Integer cardinal,
+            @RequestParam(defaultValue = "desc") String order) {
+        return ResponseEntity.ok(new BaseResponse(corporateService.getCorporateProjects(order, cardinal)));
     }
 }

--- a/src/main/java/com/kusitms/website/domain/project/ProjectController.java
+++ b/src/main/java/com/kusitms/website/domain/project/ProjectController.java
@@ -33,8 +33,10 @@ public class ProjectController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = MeetupDetailResponse.class)))
     })
-    public ResponseEntity<BaseResponse> getMeetupProjects(@RequestParam(defaultValue = "desc") String order) {
-        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects(order)));
+    public ResponseEntity<BaseResponse> getMeetupProjects(
+            @RequestParam(required = false) Integer cardinal,
+            @RequestParam(defaultValue = "desc") String order) {
+        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects(order, cardinal)));
     }
 
     @GetMapping("/meetup/{meetup_id}")

--- a/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
@@ -17,12 +17,18 @@ import java.util.stream.Collectors;
 public class CorporateService {
     private final CorporateRepository corporateRepository;
 
-    public CorporateResponse getCorporateProjects(String order) {
+    public CorporateResponse getCorporateProjects(String order, Integer cardinal) {
         List<CorporateProject> findProjects;
-        if ("asc".equals(order)) {
-            findProjects = corporateRepository.findAllByOrderByCardinalAsc();  // 오래된 순
+        if (cardinal != null) {
+            // If a cardinal is provided, filter projects by the given cardinal.
+            findProjects = corporateRepository.findAllByCardinal(cardinal);
         } else {
-            findProjects = corporateRepository.findAllByOrderByCardinalDesc();  // 최신순
+            // Otherwise, sort all projects by cardinal in the specified order.
+            if ("asc".equalsIgnoreCase(order)) {
+                findProjects = corporateRepository.findAllByOrderByCardinalAsc();  // Oldest first
+            } else {
+                findProjects = corporateRepository.findAllByOrderByCardinalDesc(); // Newest first
+            }
         }
 
         List<CorporateDetailResponse> detailResponses = findProjects.stream()

--- a/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
@@ -21,13 +21,18 @@ public class MeetupService {
     private final MeetupRepository meetupRepository;
     private final MeetupTeamRepository meetupTeamRepository;
 
-
-    public MeetupResponse getMeetupProjects(String order) {
+    public MeetupResponse getMeetupProjects(String order, Integer cardinal) {
         List<MeetupProject> findProjects;
-        if ("asc".equals(order)) {
-            findProjects = meetupRepository.findAllByOrderByCardinalAsc();  // 오래된 순
+        if (cardinal != null) {
+            // If a cardinal is provided, filter projects by the given cardinal value.
+            findProjects = meetupRepository.findAllByCardinal(cardinal);
         } else {
-            findProjects = meetupRepository.findAllByOrderByCardinalDesc();  // 최신순
+            // Otherwise, sort all projects by cardinal in the specified order.
+            if ("asc".equalsIgnoreCase(order)) {
+                findProjects = meetupRepository.findAllByOrderByCardinalAsc();  // Oldest first
+            } else {
+                findProjects = meetupRepository.findAllByOrderByCardinalDesc(); // Newest first
+            }
         }
 
         List<MeetupDetailResponse> meetupDetailResponses = findProjects.stream()


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #12 

## 💡 작업 내용
-cardinal 파라미터 값으로 기수를 받고, 해당 값으로 필터링한 리스트를 반환한다.
- 기본적으로 cardinal 파라미터가 모두 조회한다.

## 📸 스크린샷(선택)

## 🎸 기타
GET api/projects/meetup?order=desc?cardinal=30 (30기)  
GET api/projects/meetup?order=desc? (모든 기수)  
GET api/projects/corporate?order=desc?cardinal=30 (30기)  
GET api/projects/corporate?order=asc (모든 기수)