### PR TITLE
feat: (#14) 밋업/기업 프로젝트 별 다중 태그를 추가한다

### DIFF
--- a/src/main/java/com/kusitms/website/domain/project/TagRepository.java
+++ b/src/main/java/com/kusitms/website/domain/project/TagRepository.java
@@ -1,0 +1,10 @@
+package com.kusitms.website.domain.project;
+
+import com.kusitms.website.domain.project.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name); // Fetch a tag by name
+}

--- a/src/main/java/com/kusitms/website/domain/project/dto/response/CorporateDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/response/CorporateDetailResponse.java
@@ -5,6 +5,7 @@ import com.kusitms.website.domain.admin.entity.TMPCorporateProject;
 import com.kusitms.website.domain.project.entity.CorporateProject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +33,10 @@ public class CorporateDetailResponse {
     @Schema(description = "배너 이미지 URL")
     private String bannerUrl;
 
+    @Setter
+    @JsonProperty("tags")
+    private List<String> tags;
+
     public CorporateDetailResponse(CorporateProject corporate) {
         this.corporateId = corporate.getCorporateId();
         this.cardinal = corporate.getCardinal();
@@ -56,4 +61,5 @@ public class CorporateDetailResponse {
     private List<String> splitCategory(String categoryString) {
         return Arrays.asList(categoryString.split("#"));
     }
+
 }

--- a/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
@@ -6,8 +6,10 @@ import com.kusitms.website.domain.admin.entity.TMPMeetupProject;
 import com.kusitms.website.domain.project.entity.MeetupProject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static com.kusitms.website.global.util.S3Util.s3Url;
 
@@ -70,6 +72,11 @@ public class MeetupDetailResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private MeetupTeamResponse team;
 
+    @Setter
+    @Schema(description = "프로젝트 관련 태그")
+    @JsonProperty("tags")
+    private List<String> tags;
+
     public MeetupDetailResponse(MeetupProject meetup, boolean isDetail) {
         this.meetupId = meetup.getMeetupId();
         this.cardinal = meetup.getCardinal();
@@ -109,4 +116,5 @@ public class MeetupDetailResponse {
             this.team = new MeetupTeamResponse(meetup.getTeamName(), meetup.getTeam());
         }
     }
+
 }

--- a/src/main/java/com/kusitms/website/domain/project/entity/CorporateProject.java
+++ b/src/main/java/com/kusitms/website/domain/project/entity/CorporateProject.java
@@ -3,6 +3,8 @@ package com.kusitms.website.domain.project.entity;
 import lombok.Getter;
 
 import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -26,4 +28,12 @@ public class CorporateProject {
     private String bannerUrl;
 
     private String category;
+
+    @ManyToMany
+    @JoinTable(
+            name = "corporate_project_tags",
+            joinColumns = @JoinColumn(name = "corporate_project_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
 }

--- a/src/main/java/com/kusitms/website/domain/project/entity/MeetupProject.java
+++ b/src/main/java/com/kusitms/website/domain/project/entity/MeetupProject.java
@@ -8,7 +8,9 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -59,6 +61,14 @@ public class MeetupProject {
 
     @OneToMany(mappedBy = "meetupProject", cascade = CascadeType.ALL)
     private List<MeetupTeam> team = new ArrayList<>();
+
+    @ManyToMany
+    @JoinTable(
+            name = "meetup_project_tags",
+            joinColumns = @JoinColumn(name = "meetup_project_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
 
     @Builder
     public MeetupProject(int cardinal, String name, String intro, ProjectType type, String oneLineIntro,

--- a/src/main/java/com/kusitms/website/domain/project/entity/Tag.java
+++ b/src/main/java/com/kusitms/website/domain/project/entity/Tag.java
@@ -1,0 +1,29 @@
+package com.kusitms.website.domain.project.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagId;
+
+    private String name; // The actual tag name, e.g., "#지도", "#글쓰기"
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<CorporateProject> corporateProjects = new HashSet<>();
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<MeetupProject> meetupProjects = new HashSet<>();
+
+    public Tag(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/CorporateService.java
@@ -1,9 +1,11 @@
 package com.kusitms.website.domain.project.service;
 
+import com.kusitms.website.domain.project.TagRepository;
 import com.kusitms.website.domain.project.entity.CorporateProject;
 import com.kusitms.website.domain.project.dto.response.CorporateDetailResponse;
 import com.kusitms.website.domain.project.dto.response.CorporateResponse;
 import com.kusitms.website.domain.project.CorporateRepository;
+import com.kusitms.website.domain.project.entity.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class CorporateService {
     private final CorporateRepository corporateRepository;
+    private final TagRepository tagRepository;
 
     public CorporateResponse getCorporateProjects(String order, Integer cardinal) {
         List<CorporateProject> findProjects;
@@ -32,7 +35,14 @@ public class CorporateService {
         }
 
         List<CorporateDetailResponse> detailResponses = findProjects.stream()
-                .map(p -> new CorporateDetailResponse(p))
+                .map(p -> {
+                    List<String> tags = p.getTags().stream()
+                            .map(tag -> "#" + tag.getName()) // Extract tag names
+                            .collect(Collectors.toList());
+                    CorporateDetailResponse response = new CorporateDetailResponse(p);
+                    response.setTags(tags); // Set tags in response
+                    return response;
+                })
                 .collect(Collectors.toList());
 
         return CorporateResponse.builder()

--- a/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
@@ -1,11 +1,11 @@
 package com.kusitms.website.domain.project.service;
 
-import com.kusitms.website.domain.project.entity.MeetupProject;
-import com.kusitms.website.domain.project.dto.response.MeetupResponse;
-import com.kusitms.website.domain.project.dto.response.MeetupDetailResponse;
+import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.project.MeetupRepository;
 import com.kusitms.website.domain.project.MeetupTeamRepository;
-import com.kusitms.website.domain.file.S3Service;
+import com.kusitms.website.domain.project.dto.response.MeetupDetailResponse;
+import com.kusitms.website.domain.project.dto.response.MeetupResponse;
+import com.kusitms.website.domain.project.entity.MeetupProject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +36,14 @@ public class MeetupService {
         }
 
         List<MeetupDetailResponse> meetupDetailResponses = findProjects.stream()
-                .map(p -> new MeetupDetailResponse(p, false))
+                .map(p -> {
+                    List<String> tags = p.getTags().stream()
+                            .map(tag -> "#" + tag.getName()) // Extract tag names
+                            .collect(Collectors.toList());
+                    MeetupDetailResponse response = new MeetupDetailResponse(p, false);
+                    response.setTags(tags); // Set tags in response
+                    return response;
+                })
                 .collect(Collectors.toList());
 
         return MeetupResponse.builder()


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #14 

## 💡 작업 내용
- 각 밋업/기업 프로젝트 당 태그 리스트 반환
- 밋업/기업 프로젝트와 태그 엔티티는 다대다 관계
- 데이터는 피그마 보고 DB에 임의로 추가함 (기업 프로젝트는 기존 카테고리와 동일하게 설정)
- 태그 명 앞에 "#" 붙여서 반환. name 자체는 "#" 포함하지 않고 있음

## 📸 스크린샷(선택)

## 🎸 기타
API 엔드포인트는 변경된 것 없습니다 ~!