### PR TITLE
feat: (#18) 31기 전시 탭 구축 용 웹 썸네일 필드를 추가한다

### DIFF
--- a/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
@@ -46,6 +46,10 @@ public class MeetupDetailResponse {
     @Schema(description = "아이템 포스터 이미지 URL")
     private String posterUrl;
 
+    @JsonProperty("web_thumbnail_url")
+    @Schema(description = "웹 썸네일 이미지 URL")
+    private String webThumbnailUrl;
+
     @JsonProperty("instagram_url")
     @Schema(description = "인스타그램 URL")
     private String instagramUrl;
@@ -82,6 +86,7 @@ public class MeetupDetailResponse {
         this.cardinal = meetup.getCardinal();
         this.name = meetup.getName();
         this.posterUrl = s3Url + meetup.getPosterUrl();
+        this.webThumbnailUrl = meetup.getWebThumbnailUrl();
         this.logoUrl = s3Url + meetup.getLogoUrl();
         this.oneLineIntro = meetup.getOneLineIntro();
         this.instagramUrl = meetup.getInstagramUrl();

--- a/src/main/java/com/kusitms/website/domain/project/entity/MeetupProject.java
+++ b/src/main/java/com/kusitms/website/domain/project/entity/MeetupProject.java
@@ -41,6 +41,9 @@ public class MeetupProject {
     @Column(name = "poster_url", nullable = false)
     private String posterUrl;
 
+    @Column(name = "web_thumbnail_url")
+    private String webThumbnailUrl;
+
     @Column(name = "instagram_url")
     private String instagramUrl;
 
@@ -72,7 +75,7 @@ public class MeetupProject {
 
     @Builder
     public MeetupProject(int cardinal, String name, String intro, ProjectType type, String oneLineIntro,
-                         String logoUrl, String posterUrl, String instagramUrl, String githubUrl, String appUrl,
+                         String logoUrl, String posterUrl, String webThumbnailUrl, String instagramUrl, String githubUrl, String appUrl,
                          LocalDate startDate, LocalDate endDate, String teamName) {
         this.cardinal = cardinal;
         this.name = name;
@@ -81,6 +84,7 @@ public class MeetupProject {
         this.oneLineIntro = oneLineIntro;
         this.logoUrl = logoUrl;
         this.posterUrl = posterUrl;
+        this.webThumbnailUrl = webThumbnailUrl;
         this.instagramUrl = instagramUrl;
         this.githubUrl = githubUrl;
         this.appUrl = appUrl;

--- a/src/main/java/com/kusitms/website/domain/project/entity/Tag.java
+++ b/src/main/java/com/kusitms/website/domain/project/entity/Tag.java
@@ -15,7 +15,8 @@ public class Tag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tagId;
 
-    private String name; // The actual tag name, e.g., "#지도", "#글쓰기"
+    @Column(nullable = false, unique = true)
+    private String name;
 
     @ManyToMany(mappedBy = "tags")
     private Set<CorporateProject> corporateProjects = new HashSet<>();


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #18 

## 💡 작업 내용
- 태그 이름 unique, nullable=false하게 설정
- 전시 탭 구축용 웹 썸네일 필드 추가

## 📸 스크린샷(선택)

## 🎸 기타
밋업 리스트 조회 / 상세 조회 시 web_thumbnail_url 나옵니다. (등록된 것이 없을 경우 null로 반환됨)