### PR TITLE
feat: (#18) YB/OB 임의로 구분할 수 있게끔 수정한다

### DIFF
--- a/src/main/java/com/kusitms/website/domain/project/ProjectController.java
+++ b/src/main/java/com/kusitms/website/domain/project/ProjectController.java
@@ -34,9 +34,10 @@ public class ProjectController {
                     content = @Content(schema = @Schema(implementation = MeetupDetailResponse.class)))
     })
     public ResponseEntity<BaseResponse> getMeetupProjects(
+            @RequestParam(required = false) String batch,
             @RequestParam(required = false) Integer cardinal,
             @RequestParam(defaultValue = "desc") String order) {
-        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects(order, cardinal)));
+        return ResponseEntity.ok(new BaseResponse(meetupService.getMeetupProjects(order, cardinal, batch)));
     }
 
     @GetMapping("/meetup/{meetup_id}")

--- a/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
+++ b/src/main/java/com/kusitms/website/domain/project/service/MeetupService.java
@@ -21,7 +21,7 @@ public class MeetupService {
     private final MeetupRepository meetupRepository;
     private final MeetupTeamRepository meetupTeamRepository;
 
-    public MeetupResponse getMeetupProjects(String order, Integer cardinal) {
+    public MeetupResponse getMeetupProjects(String order, Integer cardinal, String batch) {
         List<MeetupProject> findProjects;
         if (cardinal != null) {
             // If a cardinal is provided, filter projects by the given cardinal value.
@@ -33,6 +33,16 @@ public class MeetupService {
             } else {
                 findProjects = meetupRepository.findAllByOrderByCardinalDesc(); // Newest first
             }
+        }
+
+        if ("OB".equalsIgnoreCase(batch)) {
+            findProjects = findProjects.stream()
+                    .filter(p -> p.getMeetupId().equals(55L))
+                    .collect(Collectors.toList());
+        } else if ("YB".equalsIgnoreCase(batch)) {
+            findProjects = findProjects.stream()
+                    .filter(p -> !p.getMeetupId().equals(55L))
+                    .collect(Collectors.toList());
         }
 
         List<MeetupDetailResponse> meetupDetailResponses = findProjects.stream()


### PR DESCRIPTION
## #️⃣ 이슈 번호
- #18 

## 💡 작업 내용
- 밋업데이 리스트 조회 시 batch 쿼리 파라미터로 OB/YB 구분해서 받을 수 있도록 수정

## 📸 스크린샷(선택)

## 🎸 기타
OB 프로젝트 하나 밖에 없어서 이거때매 필드 추가하긴 좀 번거로운 것 같아서
임의로 .. 55번 OB로 반환하고 나머지 YB로 반환하게 해뒀습니다