### PR TITLE
feat : 블로그 리스트 조회 로직 구현 (#27)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,13 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.8'
     id 'io.spring.dependency-management' version '1.1.0'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.kusitms'
@@ -43,8 +49,29 @@ dependencies {
     //json dependency
     implementation group: 'org.json', name: 'json', version: '20220320'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+
+    //queryDSL 의존성 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
 }
 
+//--------------------queryDSL 관련 추가----------------------------
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
+}
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/src/main/java/com/kusitms/website/domain/blog/controller/BlogController.java
+++ b/src/main/java/com/kusitms/website/domain/blog/controller/BlogController.java
@@ -1,0 +1,53 @@
+package com.kusitms.website.domain.blog.controller;
+
+import com.kusitms.website.domain.blog.dto.response.BlogResponse;
+import com.kusitms.website.domain.blog.entity.BlogPost;
+import com.kusitms.website.domain.blog.entity.Category;
+import com.kusitms.website.domain.blog.entity.Position;
+//import com.kusitms.website.domain.blog.service.BlogService;
+import com.kusitms.website.domain.blog.service.BlogService;
+import com.kusitms.website.domain.project.dto.response.MeetupDetailResponse;
+import com.kusitms.website.domain.project.dto.response.MeetupResponse;
+import com.kusitms.website.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/blogs")
+@RequiredArgsConstructor
+@Tag(name = "Blog", description = "블로그 API Document")
+public class BlogController {
+
+    private final BlogService blogService;
+
+    @GetMapping("")
+    @Operation(summary = "블로그 리스트 조회", description = "기수, 파트, 카테고리 조건으로 블로그 리스트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = MeetupResponse.class))),
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = MeetupDetailResponse.class)))
+    })
+    public ResponseEntity<BaseResponse> getBlogList(
+            @RequestParam(required = false) Integer generation,
+            @RequestParam(required = false) Position position,
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<BlogResponse> result = blogService.getFilteredPostsWithPaging(generation, position, category, lastId, size);
+        return ResponseEntity.ok(new BaseResponse(result));
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogResponse.java
+++ b/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogResponse.java
@@ -1,0 +1,43 @@
+package com.kusitms.website.domain.blog.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kusitms.website.domain.blog.entity.BlogAuthor;
+import com.kusitms.website.domain.blog.entity.BlogPost;
+import com.kusitms.website.domain.blog.entity.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BlogResponse {
+    @JsonProperty("blog_post_id")
+    @Schema(description = "블로그 글 아이디")
+    private Long id;
+    @Schema(description = "블로그 글 제목")
+    private String title;
+    @Schema(description = "블로그 카테고리 이름")
+    private Category category;
+    @Schema(description = "블로그 주소")
+    private String address;
+    @Schema(description = "블로그 이미지 주소")
+    private String imageAddress;
+    @Schema(description = "블로그 글 내용")
+    private String content;
+
+    public static BlogResponse fromEntity(BlogPost post) {
+        return BlogResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .category(post.getCategory())
+                .address(post.getAddress())
+                .imageAddress(post.getImageAddress())
+                .content(post.getContent())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/kusitms/website/domain/blog/entity/BlogAuthor.java
+++ b/src/main/java/com/kusitms/website/domain/blog/entity/BlogAuthor.java
@@ -1,0 +1,22 @@
+package com.kusitms.website.domain.blog.entity;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+public class BlogAuthor {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "blog_author_id", nullable = false)
+    private Long id;
+
+    @Column(length = 20)
+    private String name;
+
+    private Integer generation;
+
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+}

--- a/src/main/java/com/kusitms/website/domain/blog/entity/BlogPost.java
+++ b/src/main/java/com/kusitms/website/domain/blog/entity/BlogPost.java
@@ -1,0 +1,35 @@
+    package com.kusitms.website.domain.blog.entity;
+
+    import lombok.Getter;
+
+    import javax.persistence.*;
+    import java.time.LocalDateTime;
+
+    @Entity
+    @Getter
+    public class BlogPost {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "blog_post_id", nullable = false)
+        private Long id;
+
+        @ManyToOne
+        @JoinColumn(name = "blog_author_id")
+        private BlogAuthor blogAuthor;
+
+        @Column(length = 100)
+        private String title;
+
+        @Enumerated(EnumType.STRING)
+        private Category category;
+
+        @Column(length = 512)
+        private String address;
+
+        @Column(length = 512)
+        private String imageAddress;
+
+        @Column(columnDefinition = "TEXT")
+        private String content;
+
+    }

--- a/src/main/java/com/kusitms/website/domain/blog/entity/Category.java
+++ b/src/main/java/com/kusitms/website/domain/blog/entity/Category.java
@@ -1,0 +1,16 @@
+package com.kusitms.website.domain.blog.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    DOCUMENT("서류 후기"),
+    INTERVIEW("면접 후기"),
+    GIFT("기프 후기"),
+    MEETUP("밋업 후기"),
+    GROUP_TF("소모임/TF 후기");
+
+    private final String description;
+}

--- a/src/main/java/com/kusitms/website/domain/blog/entity/Position.java
+++ b/src/main/java/com/kusitms/website/domain/blog/entity/Position.java
@@ -1,0 +1,16 @@
+package com.kusitms.website.domain.blog.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Position {
+    FRONTEND("프론트엔드"),
+    BACKEND("백엔드"),
+    PLAN("기획"),
+    DESIGNER("디자이너");
+
+    private final String description;
+
+}

--- a/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostQueryRepository.java
+++ b/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostQueryRepository.java
@@ -1,0 +1,11 @@
+package com.kusitms.website.domain.blog.repository;
+
+import com.kusitms.website.domain.blog.entity.BlogPost;
+import com.kusitms.website.domain.blog.entity.Category;
+import com.kusitms.website.domain.blog.entity.Position;
+
+import java.util.List;
+
+public interface BlogPostQueryRepository {
+    List<BlogPost> findByFiltersWithPaging(Integer generation, Position position, Category category, Long lastId, int size);
+}

--- a/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostQueryRepositoryImpl.java
+++ b/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostQueryRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.kusitms.website.domain.blog.repository;
+
+import com.kusitms.website.domain.blog.entity.*;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class BlogPostQueryRepositoryImpl implements BlogPostQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    private final QBlogPost blogPost = QBlogPost.blogPost;
+    private final QBlogAuthor blogAuthor = QBlogAuthor.blogAuthor;
+
+    @Override
+    public List<BlogPost> findByFiltersWithPaging(Integer generation, Position position, Category category, Long lastId, int size) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (generation != null) {
+            builder.and(blogAuthor.generation.eq(generation));
+        }
+
+        if (position != null) {
+            builder.and(blogAuthor.position.eq(position));
+        }
+
+        if (category != null) {
+            builder.and(blogPost.category.eq(category));
+        }
+
+        if (lastId != null) {
+            builder.and(blogPost.id.lt(lastId));
+        }
+
+        return queryFactory
+                .selectFrom(blogPost)
+                .join(blogPost.blogAuthor, blogAuthor)
+                .where(builder)
+                .orderBy(blogPost.id.desc())
+                .limit(size)
+                .fetch();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostRepository.java
+++ b/src/main/java/com/kusitms/website/domain/blog/repository/BlogPostRepository.java
@@ -1,0 +1,7 @@
+package com.kusitms.website.domain.blog.repository;
+
+import com.kusitms.website.domain.blog.entity.BlogPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogPostRepository extends JpaRepository<BlogPost, Long>, BlogPostQueryRepository {
+}

--- a/src/main/java/com/kusitms/website/domain/blog/service/BlogService.java
+++ b/src/main/java/com/kusitms/website/domain/blog/service/BlogService.java
@@ -1,0 +1,33 @@
+package com.kusitms.website.domain.blog.service;
+
+import com.kusitms.website.domain.blog.dto.response.BlogResponse;
+import com.kusitms.website.domain.blog.entity.BlogPost;
+import com.kusitms.website.domain.blog.entity.Category;
+import com.kusitms.website.domain.blog.entity.Position;
+import com.kusitms.website.domain.blog.repository.BlogPostQueryRepository;
+import com.kusitms.website.domain.blog.repository.BlogPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+
+    private final BlogPostRepository blogPostRepository;
+
+    public List<BlogResponse> getFilteredPostsWithPaging(
+            Integer generation,
+            Position position,
+            Category category,
+            Long lastId,
+            int size
+    ) {
+        return blogPostRepository.findByFiltersWithPaging(generation, position, category, lastId, size)
+                .stream()
+                .map(BlogResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kusitms/website/global/config/QuerydslConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.kusitms.website.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
#️⃣ 이슈 번호
https://github.com/kusitms-com/api.kusitms.com/issues/27
💡 작업 내용
필터링(기수, 파트, 카테고리) 후 블로그 리스트 조회
🎸 기타
fetch join없이 쿼리 자체에서 잘라서 보내고, entity ->응답 DTO 매핑 로직 내부에서도 postAuther정보는 없으므로 성능 문제는 없을것 같습니다