### PR TITLE
feat: 어드민 기업 프로젝트/후기/블로그 후기 관리 기능 반영

### DIFF
--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -2,6 +2,7 @@ package com.kusitms.website.domain.admin;
 
 import com.kusitms.website.domain.introduction.IntroService;
 import com.kusitms.website.domain.introduction.dto.request.IntroRequest;
+import com.kusitms.website.domain.blog.dto.request.BlogReviewRequest;
 import com.kusitms.website.domain.project.dto.request.CorporateRequest;
 import com.kusitms.website.domain.project.dto.request.MeetupRequest;
 import com.kusitms.website.domain.review.dto.request.ReviewRequest;
@@ -206,5 +207,16 @@ public class AdminController {
     })
     public ResponseEntity<BaseResponse> getBlogReviews() {
         return ResponseEntity.ok(new BaseResponse(adminService.getBlogReviews()));
+    }
+
+    @PostMapping(value = "/admin/blog-review", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "블로그 후기 등록(test db)", description = "블로그 후기를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "등록 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> addBlogReview(@ModelAttribute BlogReviewRequest request) {
+        adminService.saveBlogReview(request);
+        return ResponseEntity.ok(new BaseResponse());
     }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -187,4 +187,14 @@ public class AdminController {
     public ResponseEntity<BaseResponse> getCorporateProjects() {
         return ResponseEntity.ok(new BaseResponse(adminService.getCorporateProjects()));
     }
+
+    @GetMapping("/admin/corporate/{id}")
+    @Operation(summary = "기업 프로젝트 상세 조회(test db)", description = "기업 프로젝트의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> getCorporateProject(@PathVariable("id") Long corporateId) {
+        return ResponseEntity.ok(new BaseResponse(adminService.getCorporateProject(corporateId)));
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -230,4 +230,15 @@ public class AdminController {
         adminService.updateBlogReview(request);
         return ResponseEntity.ok(new BaseResponse());
     }
+
+    @DeleteMapping("/admin/blog-review/{id}")
+    @Operation(summary = "블로그 후기 삭제(test db)", description = "블로그 후기를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> deleteBlogReview(@PathVariable("id") Long blogReviewId) {
+        adminService.deleteBlogReview(blogReviewId);
+        return ResponseEntity.ok(new BaseResponse());
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -219,4 +219,15 @@ public class AdminController {
         adminService.saveBlogReview(request);
         return ResponseEntity.ok(new BaseResponse());
     }
+
+    @PutMapping(value = "/admin/blog-review", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "블로그 후기 수정(test db)", description = "블로그 후기를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> updateBlogReview(@ModelAttribute BlogReviewRequest request) {
+        adminService.updateBlogReview(request);
+        return ResponseEntity.ok(new BaseResponse());
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -197,4 +197,14 @@ public class AdminController {
     public ResponseEntity<BaseResponse> getCorporateProject(@PathVariable("id") Long corporateId) {
         return ResponseEntity.ok(new BaseResponse(adminService.getCorporateProject(corporateId)));
     }
+
+    @GetMapping("/admin/blog-review")
+    @Operation(summary = "블로그 후기 리스트(test db)", description = "블로그 후기의 모든 리스트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> getBlogReviews() {
+        return ResponseEntity.ok(new BaseResponse(adminService.getBlogReviews()));
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -272,6 +272,7 @@ public class AdminService {
     public void updateReview(ReviewRequest request) {
       TMPReview review = reviewRepository.findById(request.getReviewId()).orElseThrow();
       review.update(request.getName(),
+              request.getCardinal(),
               request.getTeam(),
               request.getReview());
     }

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -69,6 +69,25 @@ public class AdminService {
         blogReviewRepository.save(blogReview);
     }
 
+    @Transactional
+    public void updateBlogReview(BlogReviewRequest request) {
+        TMPBlogReview blogReview = blogReviewRepository.findById(request.getBlogReviewId()).orElseThrow();
+
+        String thumbnailUrl = blogReview.getThumbnailUrl();
+        if (request.getThumbnailFile() != null && !request.getThumbnailFile().isEmpty()) {
+            thumbnailUrl = s3Service.uploadFile(request.getThumbnailFile(), "blog-review");
+        }
+
+        blogReview.update(
+                request.getCardinal(),
+                request.getPart(),
+                request.getActivity(),
+                thumbnailUrl,
+                request.getTitle(),
+                request.getPreviewText()
+        );
+    }
+
     @Transactional(readOnly = true)
     public ReviewResponse getReviews() {
         List<TMPReview> findReviews = reviewRepository.findAll();

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -1,13 +1,17 @@
 package com.kusitms.website.domain.admin;
 
 import com.kusitms.website.domain.admin.entity.TMPCorporateProject;
+import com.kusitms.website.domain.admin.entity.TMPBlogReview;
 import com.kusitms.website.domain.admin.entity.TMPMeetupProject;
 import com.kusitms.website.domain.admin.entity.TMPMeetupTeam;
 import com.kusitms.website.domain.admin.entity.TMPReview;
+import com.kusitms.website.domain.admin.repository.TMPBlogReviewRepository;
 import com.kusitms.website.domain.admin.repository.TMPCorporateRepository;
 import com.kusitms.website.domain.admin.repository.TMPMeetupRepository;
 import com.kusitms.website.domain.admin.repository.TMPMeetupTeamRepository;
 import com.kusitms.website.domain.admin.repository.TMPReviewRepository;
+import com.kusitms.website.domain.blog.dto.response.BlogReviewDetailResponse;
+import com.kusitms.website.domain.blog.dto.response.BlogReviewResponse;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.project.dto.request.CorporateRequest;
 import com.kusitms.website.domain.project.dto.request.MeetupRequest;
@@ -37,6 +41,21 @@ public class AdminService {
     private final TMPMeetupRepository meetupRepository;
     private final TMPMeetupTeamRepository meetupTeamRepository;
     private final TMPReviewRepository reviewRepository;
+    private final TMPBlogReviewRepository blogReviewRepository;
+
+    @Transactional(readOnly = true)
+    public BlogReviewResponse getBlogReviews() {
+        List<TMPBlogReview> findBlogReviews = blogReviewRepository.findAllByOrderByBlogReviewIdDesc();
+
+        List<BlogReviewDetailResponse> blogReviewDetails = findBlogReviews.stream()
+                .map(BlogReviewDetailResponse::new)
+                .collect(Collectors.toList());
+
+        return BlogReviewResponse.builder()
+                .blogReviewCount(blogReviewDetails.size())
+                .blogReviewList(blogReviewDetails)
+                .build();
+    }
 
     @Transactional(readOnly = true)
     public ReviewResponse getReviews() {

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -12,6 +12,7 @@ import com.kusitms.website.domain.admin.repository.TMPMeetupTeamRepository;
 import com.kusitms.website.domain.admin.repository.TMPReviewRepository;
 import com.kusitms.website.domain.blog.dto.response.BlogReviewDetailResponse;
 import com.kusitms.website.domain.blog.dto.response.BlogReviewResponse;
+import com.kusitms.website.domain.blog.dto.request.BlogReviewRequest;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.project.dto.request.CorporateRequest;
 import com.kusitms.website.domain.project.dto.request.MeetupRequest;
@@ -55,6 +56,17 @@ public class AdminService {
                 .blogReviewCount(blogReviewDetails.size())
                 .blogReviewList(blogReviewDetails)
                 .build();
+    }
+
+    @Transactional
+    public void saveBlogReview(BlogReviewRequest request) {
+        String thumbnailUrl = null;
+        if (request.getThumbnailFile() != null && !request.getThumbnailFile().isEmpty()) {
+            thumbnailUrl = s3Service.uploadFile(request.getThumbnailFile(), "blog-review");
+        }
+
+        TMPBlogReview blogReview = BlogReviewRequest.from(request, thumbnailUrl);
+        blogReviewRepository.save(blogReview);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -19,7 +19,6 @@ import com.kusitms.website.domain.project.entity.Team;
 import com.kusitms.website.domain.review.dto.request.ReviewRequest;
 import com.kusitms.website.domain.review.dto.response.ReviewDetailResponse;
 import com.kusitms.website.domain.review.dto.response.ReviewResponse;
-import com.kusitms.website.domain.review.entity.Review;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +43,7 @@ public class AdminService {
         List<TMPReview> findReviews = reviewRepository.findAll();
 
         List<ReviewDetailResponse> reviewDetailResponses = findReviews.stream()
-                .map(r -> new ReviewDetailResponse(r.getReviewId(), r.getName(), r.getTeam(), r.getReview()))
+                .map(r -> new ReviewDetailResponse(r.getReviewId(), r.getName(), r.getCardinal(), r.getTeam(), r.getReview()))
                 .collect(Collectors.toList());
 
         return ReviewResponse.builder()

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -88,6 +88,11 @@ public class AdminService {
         );
     }
 
+    @Transactional
+    public void deleteBlogReview(Long blogReviewId) {
+        blogReviewRepository.deleteById(blogReviewId);
+    }
+
     @Transactional(readOnly = true)
     public ReviewResponse getReviews() {
         List<TMPReview> findReviews = reviewRepository.findAll();

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -214,6 +214,12 @@ public class AdminService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
+    public CorporateDetailResponse getCorporateProject(Long corporateId) {
+        TMPCorporateProject findProject = corporateRepository.findById(corporateId).orElseThrow();
+        return new CorporateDetailResponse(findProject);
+    }
+
     @Transactional
     public void saveCorporate(CorporateRequest request) {
         String logoUrl = s3Service.uploadFile(request.getLogoFile(), "corporate");

--- a/src/main/java/com/kusitms/website/domain/admin/entity/BlogReviewActivity.java
+++ b/src/main/java/com/kusitms/website/domain/admin/entity/BlogReviewActivity.java
@@ -1,0 +1,7 @@
+package com.kusitms.website.domain.admin.entity;
+
+public enum BlogReviewActivity {
+    DOCUMENT_REVIEW,
+    INTERVIEW_REVIEW,
+    COMPANY_PROJECT
+}

--- a/src/main/java/com/kusitms/website/domain/admin/entity/TMPBlogReview.java
+++ b/src/main/java/com/kusitms/website/domain/admin/entity/TMPBlogReview.java
@@ -1,0 +1,56 @@
+package com.kusitms.website.domain.admin.entity;
+
+import com.kusitms.website.domain.project.entity.Team;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TMPBlogReview {
+    @Id
+    @Column(name = "blog_review_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long blogReviewId;
+
+    private Integer cardinal;
+
+    @Enumerated(EnumType.STRING)
+    private Team part;
+
+    @Enumerated(EnumType.STRING)
+    private BlogReviewActivity activity;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    private String title;
+
+    @Column(length = 500)
+    private String previewText;
+
+    @Builder
+    public TMPBlogReview(Integer cardinal, Team part, BlogReviewActivity activity,
+                         String thumbnailUrl, String title, String previewText) {
+        this.cardinal = cardinal;
+        this.part = part;
+        this.activity = activity;
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.previewText = previewText;
+    }
+
+    public void update(Integer cardinal, Team part, BlogReviewActivity activity,
+                       String thumbnailUrl, String title, String previewText) {
+        this.cardinal = cardinal;
+        this.part = part;
+        this.activity = activity;
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.previewText = previewText;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/admin/entity/TMPReview.java
+++ b/src/main/java/com/kusitms/website/domain/admin/entity/TMPReview.java
@@ -20,6 +20,8 @@ public class TMPReview {
     @Column(nullable = false)
     private String name;
 
+    private Integer cardinal;
+
     @Enumerated(EnumType.STRING)
     private Team team;
 
@@ -27,8 +29,9 @@ public class TMPReview {
     private String review;
 
     @Builder
-    public TMPReview(String name, Team team, String review) {
+    public TMPReview(String name, Integer cardinal, Team team, String review) {
         this.name = name;
+        this.cardinal = cardinal;
         this.team = team;
         this.review = review;
     }

--- a/src/main/java/com/kusitms/website/domain/admin/entity/TMPReview.java
+++ b/src/main/java/com/kusitms/website/domain/admin/entity/TMPReview.java
@@ -36,8 +36,9 @@ public class TMPReview {
         this.review = review;
     }
 
-    public void update(String name, Team team, String review) {
+    public void update(String name, Integer cardinal, Team team, String review) {
         this.name = name;
+        this.cardinal = cardinal;
         this.team = team;
         this.review = review;
     }

--- a/src/main/java/com/kusitms/website/domain/admin/repository/TMPBlogReviewRepository.java
+++ b/src/main/java/com/kusitms/website/domain/admin/repository/TMPBlogReviewRepository.java
@@ -1,0 +1,10 @@
+package com.kusitms.website.domain.admin.repository;
+
+import com.kusitms.website.domain.admin.entity.TMPBlogReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TMPBlogReviewRepository extends JpaRepository<TMPBlogReview, Long> {
+    List<TMPBlogReview> findAllByOrderByBlogReviewIdDesc();
+}

--- a/src/main/java/com/kusitms/website/domain/blog/dto/request/BlogReviewRequest.java
+++ b/src/main/java/com/kusitms/website/domain/blog/dto/request/BlogReviewRequest.java
@@ -1,0 +1,46 @@
+package com.kusitms.website.domain.blog.dto.request;
+
+import com.kusitms.website.domain.admin.entity.BlogReviewActivity;
+import com.kusitms.website.domain.admin.entity.TMPBlogReview;
+import com.kusitms.website.domain.project.entity.Team;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Schema
+public class BlogReviewRequest {
+    @Schema(description = "블로그 후기 ID (PUT API에서 사용)", example = "1")
+    private Long blogReviewId;
+
+    @Schema(description = "기수", example = "33")
+    private Integer cardinal;
+
+    @Schema(description = "파트", example = "PLANNER, DESIGNER, DEVELOPER")
+    private Team part;
+
+    @Schema(description = "활동", example = "DOCUMENT_REVIEW, INTERVIEW_REVIEW, COMPANY_PROJECT")
+    private BlogReviewActivity activity;
+
+    @Schema(description = "썸네일 이미지 파일")
+    private MultipartFile thumbnailFile;
+
+    @Schema(description = "제목", example = "면접에서 이런 질문이 나왔어요")
+    private String title;
+
+    @Schema(description = "미리보기 텍스트", example = "합격에 도움이 됐던 준비 과정을 공유합니다.")
+    private String previewText;
+
+    public static TMPBlogReview from(BlogReviewRequest request, String thumbnailUrl) {
+        return TMPBlogReview.builder()
+                .cardinal(request.getCardinal())
+                .part(request.getPart())
+                .activity(request.getActivity())
+                .thumbnailUrl(thumbnailUrl)
+                .title(request.getTitle())
+                .previewText(request.getPreviewText())
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogReviewDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogReviewDetailResponse.java
@@ -1,0 +1,44 @@
+package com.kusitms.website.domain.blog.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kusitms.website.domain.admin.entity.TMPBlogReview;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import static com.kusitms.website.global.util.S3Util.s3Url;
+
+@Getter
+@Schema
+public class BlogReviewDetailResponse {
+    @JsonProperty("blog_review_id")
+    @Schema(description = "블로그 후기 아이디")
+    private Long blogReviewId;
+
+    @Schema(description = "기수")
+    private Integer cardinal;
+
+    @Schema(description = "파트")
+    private String part;
+
+    @Schema(description = "활동")
+    private String activity;
+
+    @Schema(description = "썸네일 URL")
+    private String thumbnailUrl;
+
+    @Schema(description = "제목")
+    private String title;
+
+    @Schema(description = "미리보기 텍스트")
+    private String previewText;
+
+    public BlogReviewDetailResponse(TMPBlogReview blogReview) {
+        this.blogReviewId = blogReview.getBlogReviewId();
+        this.cardinal = blogReview.getCardinal();
+        this.part = blogReview.getPart() == null ? null : blogReview.getPart().name();
+        this.activity = blogReview.getActivity() == null ? null : blogReview.getActivity().name();
+        this.thumbnailUrl = blogReview.getThumbnailUrl() == null ? null : s3Url + blogReview.getThumbnailUrl();
+        this.title = blogReview.getTitle();
+        this.previewText = blogReview.getPreviewText();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogReviewResponse.java
+++ b/src/main/java/com/kusitms/website/domain/blog/dto/response/BlogReviewResponse.java
@@ -1,0 +1,21 @@
+package com.kusitms.website.domain.blog.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema
+public class BlogReviewResponse {
+    @JsonProperty("blog_review_count")
+    @Schema(description = "블로그 후기 개수")
+    private int blogReviewCount;
+
+    @JsonProperty("blog_review_list")
+    @Schema(description = "블로그 후기 리스트")
+    private List<BlogReviewDetailResponse> blogReviewList;
+}

--- a/src/main/java/com/kusitms/website/domain/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/kusitms/website/domain/review/dto/request/ReviewRequest.java
@@ -26,6 +26,7 @@ public class ReviewRequest {
     public static TMPReview from(ReviewRequest request) {
         return TMPReview.builder()
                 .name(request.getName())
+                .cardinal(request.getCardinal())
                 .team(request.getTeam())
                 .review(request.getReview())
                 .build();

--- a/src/main/java/com/kusitms/website/domain/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/kusitms/website/domain/review/dto/request/ReviewRequest.java
@@ -14,6 +14,9 @@ public class ReviewRequest {
     @Schema(description = "이름", example = "김큐시")
     private String name;
 
+    @Schema(description = "기수", example = "33")
+    private Integer cardinal;
+
     @Schema(description = "소속팀", example = "PLANNER, DESIGNER, DEVELOPER")
     private Team team;
 

--- a/src/main/java/com/kusitms/website/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/review/dto/response/ReviewDetailResponse.java
@@ -15,7 +15,7 @@ public class ReviewDetailResponse {
     @Schema(description = "이름")
     private String name;
 
-    @Schema(description = "기수")
+    @Schema(description = "기수", example = "33")
     private Integer cardinal;
 
     @Schema(description = "소속팀")


### PR DESCRIPTION
## 개요
어드민 기업 프로젝트/후기/블로그 후기 관리 기능을 요구사항에 맞게 반영했습니다.

## 변경 사항
- 기업 프로젝트: 목록/상세/등록/수정/삭제 API 반영
- 후기: cardinal 필드 추가 및 목록/등록/수정/삭제 흐름 반영
- 블로그 후기: 목록/등록/수정/삭제 API 신규 추가

## 참고 사항
현재 `/admin` 계열은 운영 데이터와 분리된 TMP 엔티티를 사용하는 기존 구조를 따르고 있어,  
이번 작업도 동일하게 TMP 기반으로 구현했습니다.

TMP 데이터와 실제 운영 도메인 데이터 통합 여부는 논의가 필요할 것 같습니다.

## 관련 이슈
- Closed #37 
- Closed #38 
- Closed #39 