### PR TITLE
feat : 어드민 밋업 프로젝트 관리 기능 보완 (#42)

### DIFF
--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -29,6 +29,16 @@ public class AdminController {
     private final AdminService adminService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @GetMapping("/admin/introductions")
+    @Operation(summary = "학회 소개 정보 조회", description = "학회 소개 페이지의 현재 저장된 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "INTER SERVER ERROR", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    public ResponseEntity<BaseResponse> getIntroduction() {
+        return ResponseEntity.ok(new BaseResponse(introService.getAdminIntroduction()));
+    }
+
     @Hidden
     @PostMapping(value = "/admin/introductions", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse> addIntroduction(@ModelAttribute IntroRequest request) {

--- a/src/main/java/com/kusitms/website/domain/admin/AdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminService.java
@@ -19,14 +19,13 @@ import com.kusitms.website.domain.project.entity.Team;
 import com.kusitms.website.domain.review.dto.request.ReviewRequest;
 import com.kusitms.website.domain.review.dto.response.ReviewDetailResponse;
 import com.kusitms.website.domain.review.dto.response.ReviewResponse;
-import com.kusitms.website.domain.review.entity.Review;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -131,8 +130,8 @@ public class AdminService {
     public void updateMeetup(MeetupRequest request) {
         TMPMeetupProject meetup = meetupRepository.findById(request.getMeetupId()).orElseThrow();
 
-        String logoUrl = s3Service.uploadFile(request.getLogoFile(), "meetup");
-        String posterUrl = s3Service.uploadFile(request.getPosterFile(), "meetup");
+        String logoUrl = uploadOrKeep(request.getLogoFile(), meetup.getLogoUrl(), "meetup");
+        String posterUrl = uploadOrKeep(request.getPosterFile(), meetup.getPosterUrl(), "meetup");
 
         meetup.update(request.getCardinal(),
                 request.getName(),
@@ -144,6 +143,7 @@ public class AdminService {
                 request.getInstagramUrl(),
                 request.getGithubUrl(),
                 request.getAppUrl(),
+                request.getBehanceUrl(),
                 LocalDate.parse(request.getStartDate(), DateTimeFormatter.ISO_DATE),
                 LocalDate.parse(request.getEndDate(), DateTimeFormatter.ISO_DATE),
                 request.getTeamName());
@@ -280,5 +280,10 @@ public class AdminService {
     @Transactional
     public void deleteReview(Long reviewId) {
         reviewRepository.deleteById(reviewId);
+    }
+
+    private String uploadOrKeep(MultipartFile file, String existingUrl, String dirName) {
+        if (file == null || file.isEmpty()) return existingUrl;
+        return s3Service.uploadFile(file, dirName);
     }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/entity/TMPMeetupProject.java
+++ b/src/main/java/com/kusitms/website/domain/admin/entity/TMPMeetupProject.java
@@ -49,6 +49,9 @@ public class TMPMeetupProject {
     @Column(name = "app_url")
     private String appUrl;
 
+    @Column(name = "behance_url")
+    private String behanceUrl;
+
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
 
@@ -64,7 +67,7 @@ public class TMPMeetupProject {
     @Builder
     public TMPMeetupProject(int cardinal, String name, String intro, ProjectType type, String oneLineIntro,
                             String logoUrl, String posterUrl, String instagramUrl, String githubUrl, String appUrl,
-                            LocalDate startDate, LocalDate endDate, String teamName) {
+                            String behanceUrl, LocalDate startDate, LocalDate endDate, String teamName) {
         this.cardinal = cardinal;
         this.name = name;
         this.intro = intro;
@@ -75,6 +78,7 @@ public class TMPMeetupProject {
         this.instagramUrl = instagramUrl;
         this.githubUrl = githubUrl;
         this.appUrl = appUrl;
+        this.behanceUrl = behanceUrl;
         this.startDate = startDate;
         this.endDate = endDate;
         this.teamName = teamName;
@@ -82,7 +86,7 @@ public class TMPMeetupProject {
 
     public void update(int cardinal, String name, String intro, ProjectType type, String oneLineIntro,
                             String logoUrl, String posterUrl, String instagramUrl, String githubUrl, String appUrl,
-                            LocalDate startDate, LocalDate endDate, String teamName) {
+                            String behanceUrl, LocalDate startDate, LocalDate endDate, String teamName) {
         this.cardinal = cardinal;
         this.name = name;
         this.intro = intro;
@@ -93,6 +97,7 @@ public class TMPMeetupProject {
         this.instagramUrl = instagramUrl;
         this.githubUrl = githubUrl;
         this.appUrl = appUrl;
+        this.behanceUrl = behanceUrl;
         this.startDate = startDate;
         this.endDate = endDate;
         this.teamName = teamName;

--- a/src/main/java/com/kusitms/website/domain/introduction/IntroService.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/IntroService.java
@@ -1,28 +1,22 @@
 package com.kusitms.website.domain.introduction;
 
 import com.kusitms.website.domain.file.S3Service;
+import com.kusitms.website.domain.introduction.dto.request.ActivityRequest;
 import com.kusitms.website.domain.introduction.dto.request.ExpertLectureRequest;
 import com.kusitms.website.domain.introduction.dto.request.IntroRequest;
 import com.kusitms.website.domain.introduction.dto.request.ManagementTeamRequest;
 import com.kusitms.website.domain.introduction.dto.request.OBLectureRequest;
-import com.kusitms.website.domain.introduction.dto.response.ExpertLectureResponse;
-import com.kusitms.website.domain.introduction.dto.response.IntroResponse;
-import com.kusitms.website.domain.introduction.dto.response.ManagementTeamResponse;
-import com.kusitms.website.domain.introduction.dto.response.OBLectureResponse;
-import com.kusitms.website.domain.introduction.entity.ExpertLecture;
-import com.kusitms.website.domain.introduction.entity.Introduction;
-import com.kusitms.website.domain.introduction.entity.ManageTeam;
-import com.kusitms.website.domain.introduction.entity.OBLecture;
-import com.kusitms.website.domain.introduction.repository.ExpertLectureRepository;
-import com.kusitms.website.domain.introduction.repository.IntroRepository;
-import com.kusitms.website.domain.introduction.repository.ManageTeamRepository;
-import com.kusitms.website.domain.introduction.repository.OBLectureRepository;
+import com.kusitms.website.domain.introduction.dto.response.*;
+import com.kusitms.website.domain.introduction.entity.*;
+import com.kusitms.website.domain.introduction.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.persistence.EntityNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -34,90 +28,241 @@ public class IntroService {
     private final ManageTeamRepository manageTeamRepository;
     private final ExpertLectureRepository expertLectureRepository;
     private final OBLectureRepository obLectureRepository;
-
+    private final PartnerLogoRepository partnerLogoRepository;
+    private final IntroMeetupImageRepository introMeetupImageRepository;
+    private final ActivityRepository activityRepository;
+    private final SponsorRepository sponsorRepository;
 
     private final String dirName = "intro";
 
     @Transactional(readOnly = true)
     public IntroResponse getIntroduction() {
-        // 학회 소개 페이지 정보는 단일
-        Introduction intro = introRepository.findAll().get(0);
+        Introduction intro = introRepository.findAll().stream().findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("학회 소개 정보가 존재하지 않습니다."));
 
         List<ManagementTeamResponse> managementTeamResponses = intro.getManageTeam().stream()
-                .map(ManagementTeamResponse :: fromEntity)
+                .map(ManagementTeamResponse::fromEntity)
                 .collect(Collectors.toList());
 
         List<ExpertLectureResponse> expertLectureResponses = intro.getExpertLecture().stream()
-                .map(ExpertLectureResponse :: fromEntity)
+                .map(ExpertLectureResponse::fromEntity)
                 .collect(Collectors.toList());
 
         List<OBLectureResponse> obLectureResponses = intro.getObLecture().stream()
-                .map(OBLectureResponse :: fromEntity)
+                .map(OBLectureResponse::fromEntity)
                 .collect(Collectors.toList());
 
-        return IntroResponse.fromEntity(intro, managementTeamResponses, expertLectureResponses, obLectureResponses);
+        List<String> partnerLogoUrls = intro.getPartnerLogos().stream()
+                .map(PartnerLogo::getImageUrl)
+                .collect(Collectors.toList());
+
+        List<String> meetupImageUrls = intro.getMeetupImages().stream()
+                .map(IntroMeetupImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        List<ActivityResponse> activityResponses = intro.getActivities().stream()
+                .map(ActivityResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<String> sponsorImageUrls = intro.getSponsors().stream()
+                .map(Sponsor::getImageUrl)
+                .collect(Collectors.toList());
+
+        return IntroResponse.fromEntity(intro, partnerLogoUrls, meetupImageUrls,
+                managementTeamResponses, expertLectureResponses, obLectureResponses,
+                activityResponses, sponsorImageUrls);
     }
 
-    @Transactional()
+    @Transactional(readOnly = true)
+    public AdminIntroResponse getAdminIntroduction() {
+        Introduction intro = introRepository.findAll().stream().findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("학회 소개 정보가 존재하지 않습니다."));
+
+        List<ManagementTeamResponse> teams = intro.getManageTeam().stream()
+                .map(ManagementTeamResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<ExpertLectureResponse> expertLectures = intro.getExpertLecture().stream()
+                .map(ExpertLectureResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<OBLectureResponse> obLectures = intro.getObLecture().stream()
+                .map(OBLectureResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<String> partnerLogoUrls = intro.getPartnerLogos().stream()
+                .map(PartnerLogo::getImageUrl)
+                .collect(Collectors.toList());
+
+        List<String> meetupImageUrls = intro.getMeetupImages().stream()
+                .map(IntroMeetupImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        List<ActivityResponse> activityResponses = intro.getActivities().stream()
+                .map(ActivityResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        List<String> sponsorImageUrls = intro.getSponsors().stream()
+                .map(Sponsor::getImageUrl)
+                .collect(Collectors.toList());
+
+        return AdminIntroResponse.fromEntity(intro, partnerLogoUrls, meetupImageUrls,
+                activityResponses, teams, expertLectures, obLectures, sponsorImageUrls);
+    }
+
+    @Transactional
     public void save(IntroRequest request) {
-        String partnerImageUrl = s3Service.uploadFile(request.getPartnerLogoFile(), dirName);
-        Introduction introduction = IntroRequest.from(request, partnerImageUrl);
+        String bannerImageUrl = uploadIfPresent(request.getBannerImageFile());
+        String planningImageUrl = uploadIfPresent(request.getPlanningImage());
+        String designImageUrl = uploadIfPresent(request.getDesignImage());
+        String frontendImageUrl = uploadIfPresent(request.getFrontendImage());
+        String backendImageUrl = uploadIfPresent(request.getBackendImage());
+
+        Introduction introduction = IntroRequest.from(request, null,
+                bannerImageUrl, planningImageUrl, designImageUrl, frontendImageUrl, backendImageUrl);
         introRepository.save(introduction);
 
-        List<ManageTeam> manageTeam = request.getTeams().stream()
-                .map(team -> ManagementTeamRequest.from(team, s3Service.uploadFile(team.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        List<ExpertLecture> expertLecture = request.getExpertLecture().stream()
-                .map(lecture -> ExpertLectureRequest.from(lecture, s3Service.uploadFile(lecture.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        List<OBLecture> obLecture = request.getObLecture().stream()
-                .map(lecture -> OBLectureRequest.from(lecture, s3Service.uploadFile(lecture.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        manageTeamRepository.saveAll(manageTeam);
-        expertLectureRepository.saveAll(expertLecture);
-        obLectureRepository.saveAll(obLecture);
-
-        return;
+        saveManageTeams(request, introduction);
+        saveExpertLectures(request, introduction);
+        saveOBLectures(request, introduction);
+        savePartnerLogos(request.getPartnerLogoFiles(), introduction);
+        saveMeetupImages(request.getMeetupImages(), introduction);
+        saveActivities(request.getActivities(), introduction);
+        saveSponsors(request.getSponsors(), introduction);
     }
 
-    @Transactional()
+    @Transactional
     public void updateIntroduction(IntroRequest request) {
-        String partnerImageUrl = s3Service.uploadFile(request.getPartnerLogoFile(), dirName);
-        Introduction introduction = introRepository.findAll().get(0);
+        Introduction introduction = introRepository.findAll().stream().findFirst()
+                .orElseThrow(() -> new EntityNotFoundException("학회 소개 정보가 존재하지 않습니다."));
+
+        String bannerImageUrl = uploadOrKeep(request.getBannerImageFile(), introduction.getBannerImageUrl());
+        String planningImageUrl = uploadOrKeep(request.getPlanningImage(), introduction.getPlanningImageUrl());
+        String designImageUrl = uploadOrKeep(request.getDesignImage(), introduction.getDesignImageUrl());
+        String frontendImageUrl = uploadOrKeep(request.getFrontendImage(), introduction.getFrontendImageUrl());
+        String backendImageUrl = uploadOrKeep(request.getBackendImage(), introduction.getBackendImageUrl());
+
         introduction.update(request.getBannerCardinal(),
                 request.getBannerStatus(),
+                request.getSlogan(),
+                bannerImageUrl,
                 request.getMemberCount(),
                 request.getProjectCount(),
                 request.getUniversityCount(),
-                partnerImageUrl,
-                request.getIntroYoutubeLink());
+                null,
+                request.getIntroYoutubeLink(),
+                planningImageUrl,
+                designImageUrl,
+                frontendImageUrl,
+                backendImageUrl);
 
         introRepository.save(introduction);
 
-        manageTeamRepository.deleteAll();
-        expertLectureRepository.deleteAll();
-        obLectureRepository.deleteAll();
+        manageTeamRepository.deleteByIntroduction(introduction);
+        expertLectureRepository.deleteByIntroduction(introduction);
+        obLectureRepository.deleteByIntroduction(introduction);
+        partnerLogoRepository.deleteByIntroduction(introduction);
+        introMeetupImageRepository.deleteByIntroduction(introduction);
+        activityRepository.deleteByIntroduction(introduction);
+        sponsorRepository.deleteByIntroduction(introduction);
 
-        List<ManageTeam> manageTeam = request.getTeams().stream()
-                .map(team -> ManagementTeamRequest.from(team, s3Service.uploadFile(team.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        List<ExpertLecture> expertLecture = request.getExpertLecture().stream()
-                .map(lecture -> ExpertLectureRequest.from(lecture, s3Service.uploadFile(lecture.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        List<OBLecture> obLecture = request.getObLecture().stream()
-                .map(lecture -> OBLectureRequest.from(lecture, s3Service.uploadFile(lecture.getImageFile(), dirName), introduction))
-                .collect(Collectors.toList());
-
-        manageTeamRepository.saveAll(manageTeam);
-        expertLectureRepository.saveAll(expertLecture);
-        obLectureRepository.saveAll(obLecture);
-
-        return;
+        saveManageTeams(request, introduction);
+        saveExpertLectures(request, introduction);
+        saveOBLectures(request, introduction);
+        savePartnerLogos(request.getPartnerLogoFiles(), introduction);
+        saveMeetupImages(request.getMeetupImages(), introduction);
+        saveActivities(request.getActivities(), introduction);
+        saveSponsors(request.getSponsors(), introduction);
     }
 
+    private void saveManageTeams(IntroRequest request, Introduction introduction) {
+        if (request.getTeams() == null) return;
+        List<ManageTeam> manageTeams = request.getTeams().stream()
+                .map(team -> {
+                    String imageUrl = uploadIfPresent(team.getImageFile());
+                    return ManagementTeamRequest.from(team, imageUrl, introduction);
+                })
+                .collect(Collectors.toList());
+        manageTeamRepository.saveAll(manageTeams);
+    }
+
+    private void saveExpertLectures(IntroRequest request, Introduction introduction) {
+        if (request.getExpertLecture() == null) return;
+        List<ExpertLecture> expertLectures = request.getExpertLecture().stream()
+                .map(lecture -> {
+                    String imageUrl = uploadIfPresent(lecture.getImageFile());
+                    return ExpertLectureRequest.from(lecture, imageUrl, introduction);
+                })
+                .collect(Collectors.toList());
+        expertLectureRepository.saveAll(expertLectures);
+    }
+
+    private void saveOBLectures(IntroRequest request, Introduction introduction) {
+        if (request.getObLecture() == null) return;
+        List<OBLecture> obLectures = request.getObLecture().stream()
+                .map(lecture -> {
+                    String imageUrl = uploadIfPresent(lecture.getImageFile());
+                    return OBLectureRequest.from(lecture, imageUrl, introduction);
+                })
+                .collect(Collectors.toList());
+        obLectureRepository.saveAll(obLectures);
+    }
+
+    private void savePartnerLogos(List<MultipartFile> files, Introduction introduction) {
+        if (files == null) return;
+        List<PartnerLogo> logos = files.stream()
+                .filter(f -> f != null && !f.isEmpty())
+                .map(f -> PartnerLogo.builder()
+                        .introduction(introduction)
+                        .imageUrl(s3Service.uploadFile(f, dirName))
+                        .build())
+                .collect(Collectors.toList());
+        partnerLogoRepository.saveAll(logos);
+    }
+
+    private void saveMeetupImages(List<MultipartFile> files, Introduction introduction) {
+        if (files == null) return;
+        List<IntroMeetupImage> images = files.stream()
+                .filter(f -> f != null && !f.isEmpty())
+                .map(f -> IntroMeetupImage.builder()
+                        .introduction(introduction)
+                        .imageUrl(s3Service.uploadFile(f, dirName))
+                        .build())
+                .collect(Collectors.toList());
+        introMeetupImageRepository.saveAll(images);
+    }
+
+    private void saveActivities(List<ActivityRequest> activityRequests, Introduction introduction) {
+        if (activityRequests == null) return;
+        List<Activity> activities = activityRequests.stream()
+                .map(req -> {
+                    String imageUrl1 = uploadIfPresent(req.getImageFile1());
+                    String imageUrl2 = uploadIfPresent(req.getImageFile2());
+                    return ActivityRequest.from(req, imageUrl1, imageUrl2, introduction);
+                })
+                .collect(Collectors.toList());
+        activityRepository.saveAll(activities);
+    }
+
+    private void saveSponsors(List<MultipartFile> files, Introduction introduction) {
+        if (files == null) return;
+        List<Sponsor> sponsors = files.stream()
+                .filter(f -> f != null && !f.isEmpty())
+                .map(f -> Sponsor.builder()
+                        .introduction(introduction)
+                        .imageUrl(s3Service.uploadFile(f, dirName))
+                        .build())
+                .collect(Collectors.toList());
+        sponsorRepository.saveAll(sponsors);
+    }
+
+    private String uploadIfPresent(MultipartFile file) {
+        if (file == null || file.isEmpty()) return null;
+        return s3Service.uploadFile(file, dirName);
+    }
+
+    private String uploadOrKeep(MultipartFile file, String existingUrl) {
+        if (file == null || file.isEmpty()) return existingUrl;
+        return s3Service.uploadFile(file, dirName);
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/dto/request/ActivityRequest.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/dto/request/ActivityRequest.java
@@ -1,0 +1,36 @@
+package com.kusitms.website.domain.introduction.dto.request;
+
+import com.kusitms.website.domain.introduction.entity.Activity;
+import com.kusitms.website.domain.introduction.entity.Introduction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Schema
+public class ActivityRequest {
+    @Schema(description = "활동명", example = "밋업데이")
+    private String name;
+
+    @Schema(description = "활동 이미지 1")
+    private MultipartFile imageFile1;
+
+    @Schema(description = "활동 이미지 2")
+    private MultipartFile imageFile2;
+
+    @Schema(description = "활동 설명글", example = "밋업데이는 ~입니다.")
+    private String description;
+
+    public static Activity from(ActivityRequest request, String imageUrl1, String imageUrl2,
+                                Introduction introduction) {
+        return Activity.builder()
+                .name(request.getName())
+                .imageUrl1(imageUrl1)
+                .imageUrl2(imageUrl2)
+                .description(request.getDescription())
+                .introduction(introduction)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/dto/request/IntroRequest.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/dto/request/IntroRequest.java
@@ -7,20 +7,25 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
-@Schema
+@Schema(description = "학회 소개 요청")
 public class IntroRequest {
     @Schema(description = "배너 내에 삽입되는 기수", example = "27")
     private Long bannerCardinal;
 
-    @Schema(description = "배너 상태 (대문자 영문 코드)", example = "CLOSE/MANAGEMENT_RECRUIT/MEMBER_RECRUIT")
+    @Schema(description = "배너 상태 (대문자 영문 코드)", example = "CLOSE")
     private BannerStatus bannerStatus;
 
-    @Schema(description = "누적 학회원 수 ", example = "1432")
+    @Schema(description = "슬로건", example = "큐시즘, 함께 성장하는 IT 학회")
+    private String slogan;
+
+    @Schema(description = "배너 이미지 파일")
+    private MultipartFile bannerImageFile;
+
+    @Schema(description = "누적 학회원 수", example = "1432")
     private Long memberCount;
 
     @Schema(description = "누적 프로젝트 결과물 수", example = "322")
@@ -32,27 +37,57 @@ public class IntroRequest {
     @Schema(description = "학회 소개 영상", example = "https://www.youtube.com/")
     private String introYoutubeLink;
 
+    @Schema(description = "기획 이미지 파일")
+    private MultipartFile planningImage;
+
+    @Schema(description = "디자인 이미지 파일")
+    private MultipartFile designImage;
+
+    @Schema(description = "프론트 이미지 파일")
+    private MultipartFile frontendImage;
+
+    @Schema(description = "백엔드 이미지 파일")
+    private MultipartFile backendImage;
+
     @Schema(description = "학회 운영진 소개")
-    private List<ManagementTeamRequest> teams = new ArrayList<>();;
+    private List<ManagementTeamRequest> teams;
 
     @Schema(description = "전문가 초청 강연자 소개")
-    private List<ExpertLectureRequest> expertLecture = new ArrayList<>();
+    private List<ExpertLectureRequest> expertLecture;
 
-    @Schema(description = "ob 초청 강연자 소개")
-    private List<OBLectureRequest> obLecture = new ArrayList<>();
+    @Schema(description = "OB 초청 강연자 소개")
+    private List<OBLectureRequest> obLecture;
 
-    @Schema(description = "파트너사 소개 이미지 파일")
-    private MultipartFile partnerLogoFile;
+    @Schema(description = "파트너사 로고 이미지 파일 목록")
+    private List<MultipartFile> partnerLogoFiles;
 
-    public static Introduction from(IntroRequest request, String partnerImageUrl) {
+    @Schema(description = "밋업 이미지 파일 목록")
+    private List<MultipartFile> meetupImages;
+
+    @Schema(description = "활동 소개 목록")
+    private List<ActivityRequest> activities;
+
+    @Schema(description = "후원사 이미지 파일 목록")
+    private List<MultipartFile> sponsors;
+
+    public static Introduction from(IntroRequest request, String partnerImageUrl,
+                                     String bannerImageUrl,
+                                     String planningImageUrl, String designImageUrl,
+                                     String frontendImageUrl, String backendImageUrl) {
         return Introduction.builder()
                 .bannerCardinal(request.getBannerCardinal())
                 .bannerStatus(request.getBannerStatus())
+                .slogan(request.getSlogan())
+                .bannerImageUrl(bannerImageUrl)
                 .memberCount(request.getMemberCount())
                 .projectCount(request.getProjectCount())
                 .universityCount(request.getUniversityCount())
                 .introYoutubeLink(request.getIntroYoutubeLink())
                 .partnerImageUrl(partnerImageUrl)
+                .planningImageUrl(planningImageUrl)
+                .designImageUrl(designImageUrl)
+                .frontendImageUrl(frontendImageUrl)
+                .backendImageUrl(backendImageUrl)
                 .build();
     }
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/dto/response/ActivityResponse.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/dto/response/ActivityResponse.java
@@ -1,0 +1,35 @@
+package com.kusitms.website.domain.introduction.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kusitms.website.domain.introduction.entity.Activity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema
+public class ActivityResponse {
+    @Schema(description = "활동명", example = "밋업데이")
+    private String name;
+
+    @JsonProperty("image_url1")
+    @Schema(description = "활동 이미지 1 URL")
+    private String imageUrl1;
+
+    @JsonProperty("image_url2")
+    @Schema(description = "활동 이미지 2 URL")
+    private String imageUrl2;
+
+    @Schema(description = "활동 설명글")
+    private String description;
+
+    public static ActivityResponse fromEntity(Activity activity) {
+        return ActivityResponse.builder()
+                .name(activity.getName())
+                .imageUrl1(activity.getImageUrl1())
+                .imageUrl2(activity.getImageUrl2())
+                .description(activity.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/dto/response/AdminIntroResponse.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/dto/response/AdminIntroResponse.java
@@ -1,0 +1,118 @@
+package com.kusitms.website.domain.introduction.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kusitms.website.domain.introduction.entity.Introduction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema
+public class AdminIntroResponse {
+    @JsonProperty("banner_cardinal")
+    @Schema(description = "배너 기수")
+    private Long bannerCardinal;
+
+    @JsonProperty("banner_status")
+    @Schema(description = "배너 상태")
+    private String bannerStatus;
+
+    @Schema(description = "슬로건")
+    private String slogan;
+
+    @JsonProperty("banner_image_url")
+    @Schema(description = "배너 이미지 URL")
+    private String bannerImageUrl;
+
+    @JsonProperty("member_count")
+    @Schema(description = "누적 학회원 수")
+    private Long memberCount;
+
+    @JsonProperty("project_count")
+    @Schema(description = "누적 프로젝트 수")
+    private Long projectCount;
+
+    @JsonProperty("university_count")
+    @Schema(description = "참여 대학 수")
+    private Long universityCount;
+
+    @JsonProperty("intro_youtube_link")
+    @Schema(description = "학회 소개 영상")
+    private String introYoutubeLink;
+
+    @JsonProperty("planning_image_url")
+    @Schema(description = "기획 이미지 URL")
+    private String planningImageUrl;
+
+    @JsonProperty("design_image_url")
+    @Schema(description = "디자인 이미지 URL")
+    private String designImageUrl;
+
+    @JsonProperty("frontend_image_url")
+    @Schema(description = "프론트 이미지 URL")
+    private String frontendImageUrl;
+
+    @JsonProperty("backend_image_url")
+    @Schema(description = "백엔드 이미지 URL")
+    private String backendImageUrl;
+
+    @JsonProperty("partner_logo_urls")
+    @Schema(description = "파트너사 로고 이미지 URL 목록")
+    private List<String> partnerLogoUrls;
+
+    @JsonProperty("meetup_image_urls")
+    @Schema(description = "밋업 이미지 URL 목록")
+    private List<String> meetupImageUrls;
+
+    @Schema(description = "활동 소개 목록")
+    private List<ActivityResponse> activities;
+
+    @Schema(description = "운영진 소개")
+    private List<ManagementTeamResponse> teams;
+
+    @JsonProperty("expert_lecture")
+    @Schema(description = "전문가 초청 강연자 소개")
+    private List<ExpertLectureResponse> expertLecture;
+
+    @JsonProperty("ob_lecture")
+    @Schema(description = "OB 초청 강연자 소개")
+    private List<OBLectureResponse> obLecture;
+
+    @JsonProperty("sponsor_image_urls")
+    @Schema(description = "후원사 이미지 URL 목록")
+    private List<String> sponsorImageUrls;
+
+    public static AdminIntroResponse fromEntity(Introduction intro,
+                                                 List<String> partnerLogoUrls,
+                                                 List<String> meetupImageUrls,
+                                                 List<ActivityResponse> activities,
+                                                 List<ManagementTeamResponse> teams,
+                                                 List<ExpertLectureResponse> expertLecture,
+                                                 List<OBLectureResponse> obLecture,
+                                                 List<String> sponsorImageUrls) {
+        return AdminIntroResponse.builder()
+                .bannerCardinal(intro.getBannerCardinal())
+                .bannerStatus(intro.getBannerStatus() != null ? intro.getBannerStatus().name() : null)
+                .slogan(intro.getSlogan())
+                .bannerImageUrl(intro.getBannerImageUrl())
+                .memberCount(intro.getMemberCount())
+                .projectCount(intro.getProjectCount())
+                .universityCount(intro.getUniversityCount())
+                .introYoutubeLink(intro.getIntroYoutubeLink())
+                .planningImageUrl(intro.getPlanningImageUrl())
+                .designImageUrl(intro.getDesignImageUrl())
+                .frontendImageUrl(intro.getFrontendImageUrl())
+                .backendImageUrl(intro.getBackendImageUrl())
+                .partnerLogoUrls(partnerLogoUrls)
+                .meetupImageUrls(meetupImageUrls)
+                .activities(activities)
+                .teams(teams)
+                .expertLecture(expertLecture)
+                .obLecture(obLecture)
+                .sponsorImageUrls(sponsorImageUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/dto/response/IntroResponse.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/dto/response/IntroResponse.java
@@ -20,6 +20,13 @@ public class IntroResponse {
     @Schema(description = "배너 내용", example = "KUSITMS 27기 리크루팅 종료")
     private String bannerContent;
 
+    @Schema(description = "슬로건")
+    private String slogan;
+
+    @JsonProperty("banner_image_url")
+    @Schema(description = "배너 이미지 URL")
+    private String bannerImageUrl;
+
     @JsonProperty("member_count")
     @Schema(description = "누적 학회원 수", example = "1432")
     private Long memberCount;
@@ -36,9 +43,29 @@ public class IntroResponse {
     @Schema(description = "학회 소개 영상", example = "https://www.youtube.com/")
     private String introYoutubeLink;
 
-    @JsonProperty("parent_logo_url")
-    @Schema(description = "파트너사 소개 이미지 URL")
-    private String partnerLogoUrl;
+    @JsonProperty("planning_image_url")
+    @Schema(description = "기획 이미지 URL")
+    private String planningImageUrl;
+
+    @JsonProperty("design_image_url")
+    @Schema(description = "디자인 이미지 URL")
+    private String designImageUrl;
+
+    @JsonProperty("frontend_image_url")
+    @Schema(description = "프론트 이미지 URL")
+    private String frontendImageUrl;
+
+    @JsonProperty("backend_image_url")
+    @Schema(description = "백엔드 이미지 URL")
+    private String backendImageUrl;
+
+    @JsonProperty("partner_logo_urls")
+    @Schema(description = "파트너사 로고 이미지 URL 목록")
+    private List<String> partnerLogoUrls;
+
+    @JsonProperty("meetup_image_urls")
+    @Schema(description = "밋업 이미지 URL 목록")
+    private List<String> meetupImageUrls;
 
     @Schema(description = "학회 운영진 소개")
     private List<ManagementTeamResponse> teams;
@@ -51,21 +78,43 @@ public class IntroResponse {
     @Schema(description = "ob 초청 강연자 소개")
     private List<OBLectureResponse> obLecture;
 
-    public static IntroResponse fromEntity(Introduction introduction, List<ManagementTeamResponse> managementTeam,
-                               List<ExpertLectureResponse> expertLecture, List<OBLectureResponse> obLecture) {
+    @Schema(description = "활동 소개 목록")
+    private List<ActivityResponse> activities;
+
+    @JsonProperty("sponsor_image_urls")
+    @Schema(description = "후원사 이미지 URL 목록")
+    private List<String> sponsorImageUrls;
+
+    public static IntroResponse fromEntity(Introduction introduction,
+                                           List<String> partnerLogoUrls,
+                                           List<String> meetupImageUrls,
+                                           List<ManagementTeamResponse> managementTeam,
+                                           List<ExpertLectureResponse> expertLecture,
+                                           List<OBLectureResponse> obLecture,
+                                           List<ActivityResponse> activities,
+                                           List<String> sponsorImageUrls) {
         return IntroResponse.builder()
-                .bannerStatus(introduction.getBannerStatus().getName())
-                .bannerContent("KUSITMS"
-                        + introduction.getBannerCardinal() + "기 "
-                        + introduction.getBannerStatus().getContent())
+                .bannerStatus(introduction.getBannerStatus() != null ? introduction.getBannerStatus().getName() : null)
+                .bannerContent(introduction.getBannerStatus() != null
+                        ? "KUSITMS" + introduction.getBannerCardinal() + "기 " + introduction.getBannerStatus().getContent()
+                        : null)
+                .slogan(introduction.getSlogan())
+                .bannerImageUrl(introduction.getBannerImageUrl())
                 .memberCount(introduction.getMemberCount())
                 .projectCount(introduction.getProjectCount())
                 .universityCount(introduction.getUniversityCount())
                 .introYoutubeLink(introduction.getIntroYoutubeLink())
-                .partnerLogoUrl(introduction.getPartnerImageUrl())
+                .planningImageUrl(introduction.getPlanningImageUrl())
+                .designImageUrl(introduction.getDesignImageUrl())
+                .frontendImageUrl(introduction.getFrontendImageUrl())
+                .backendImageUrl(introduction.getBackendImageUrl())
+                .partnerLogoUrls(partnerLogoUrls)
+                .meetupImageUrls(meetupImageUrls)
                 .teams(managementTeam)
                 .expertLecture(expertLecture)
                 .obLecture(obLecture)
+                .activities(activities)
+                .sponsorImageUrls(sponsorImageUrls)
                 .build();
     }
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/entity/Activity.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/entity/Activity.java
@@ -1,0 +1,44 @@
+package com.kusitms.website.domain.introduction.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Activity {
+    @Id
+    @Column(name = "activity_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long activityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "introduction_id")
+    private Introduction introduction;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "image_url1")
+    private String imageUrl1;
+
+    @Column(name = "image_url2")
+    private String imageUrl2;
+
+    @Column(length = 500)
+    private String description;
+
+    @Builder
+    public Activity(Introduction introduction, String name, String imageUrl1,
+                    String imageUrl2, String description) {
+        this.introduction = introduction;
+        this.name = name;
+        this.imageUrl1 = imageUrl1;
+        this.imageUrl2 = imageUrl2;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/entity/IntroMeetupImage.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/entity/IntroMeetupImage.java
@@ -1,0 +1,31 @@
+package com.kusitms.website.domain.introduction.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IntroMeetupImage {
+    @Id
+    @Column(name = "meetup_image_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long meetupImageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "introduction_id")
+    private Introduction introduction;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public IntroMeetupImage(Introduction introduction, String imageUrl) {
+        this.introduction = introduction;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/entity/Introduction.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/entity/Introduction.java
@@ -24,6 +24,10 @@ public class Introduction {
     @Column(name = "banner_status")
     @Enumerated(EnumType.STRING)
     private BannerStatus bannerStatus;
+    @Column(name = "slogan", length = 50)
+    private String slogan;
+    @Column(name = "banner_image_url")
+    private String bannerImageUrl;
 
     // 학회 정보
     @Column(name = "member_count")
@@ -37,9 +41,19 @@ public class Introduction {
     @Column(name = "intro_youtube_link")
     private String introYoutubeLink;
 
-    // 파트너사 이미지
+    // 파트너사 이미지 (기존 단일 필드 유지 — 하위호환)
     @Column(name = "partner_image_url")
     private String partnerImageUrl;
+
+    // 함께하는 큐밀리 이미지
+    @Column(name = "planning_image_url")
+    private String planningImageUrl;
+    @Column(name = "design_image_url")
+    private String designImageUrl;
+    @Column(name = "frontend_image_url")
+    private String frontendImageUrl;
+    @Column(name = "backend_image_url")
+    private String backendImageUrl;
 
     // 운영진 소개
     @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
@@ -53,32 +67,62 @@ public class Introduction {
     @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
     private List<OBLecture> obLecture = new ArrayList<>();
 
+    // 파트너사 로고 목록 (배열)
+    @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
+    private List<PartnerLogo> partnerLogos = new ArrayList<>();
+
+    // 밋업 이미지 목록
+    @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
+    private List<IntroMeetupImage> meetupImages = new ArrayList<>();
+
+    // 활동 소개
+    @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
+    private List<Activity> activities = new ArrayList<>();
+
+    // 후원사
+    @OneToMany(mappedBy = "introduction", cascade = CascadeType.ALL)
+    private List<Sponsor> sponsors = new ArrayList<>();
 
     @Builder
-    public Introduction(Long bannerCardinal, BannerStatus bannerStatus,
+    public Introduction(Long bannerCardinal, BannerStatus bannerStatus, String slogan, String bannerImageUrl,
                         Long memberCount, Long projectCount, Long universityCount,
-                        String partnerImageUrl, String introYoutubeLink)
+                        String partnerImageUrl, String introYoutubeLink,
+                        String planningImageUrl, String designImageUrl,
+                        String frontendImageUrl, String backendImageUrl)
     {
         this.bannerCardinal = bannerCardinal;
         this.bannerStatus = bannerStatus;
+        this.slogan = slogan;
+        this.bannerImageUrl = bannerImageUrl;
         this.memberCount = memberCount;
         this.projectCount = projectCount;
         this.universityCount = universityCount;
         this.partnerImageUrl = partnerImageUrl;
         this.introYoutubeLink = introYoutubeLink;
+        this.planningImageUrl = planningImageUrl;
+        this.designImageUrl = designImageUrl;
+        this.frontendImageUrl = frontendImageUrl;
+        this.backendImageUrl = backendImageUrl;
     }
 
-    public void update(Long bannerCardinal, BannerStatus bannerStatus,
+    public void update(Long bannerCardinal, BannerStatus bannerStatus, String slogan, String bannerImageUrl,
                         Long memberCount, Long projectCount, Long universityCount,
-                        String partnerImageUrl, String introYoutubeLink)
+                        String partnerImageUrl, String introYoutubeLink,
+                        String planningImageUrl, String designImageUrl,
+                        String frontendImageUrl, String backendImageUrl)
     {
         this.bannerCardinal = bannerCardinal;
         this.bannerStatus = bannerStatus;
+        this.slogan = slogan;
+        this.bannerImageUrl = bannerImageUrl;
         this.memberCount = memberCount;
         this.projectCount = projectCount;
         this.universityCount = universityCount;
         this.partnerImageUrl = partnerImageUrl;
         this.introYoutubeLink = introYoutubeLink;
+        this.planningImageUrl = planningImageUrl;
+        this.designImageUrl = designImageUrl;
+        this.frontendImageUrl = frontendImageUrl;
+        this.backendImageUrl = backendImageUrl;
     }
-
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/entity/PartnerLogo.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/entity/PartnerLogo.java
@@ -1,0 +1,31 @@
+package com.kusitms.website.domain.introduction.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartnerLogo {
+    @Id
+    @Column(name = "partner_logo_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long partnerLogoId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "introduction_id")
+    private Introduction introduction;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public PartnerLogo(Introduction introduction, String imageUrl) {
+        this.introduction = introduction;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/entity/Sponsor.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/entity/Sponsor.java
@@ -1,0 +1,31 @@
+package com.kusitms.website.domain.introduction.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sponsor {
+    @Id
+    @Column(name = "sponsor_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long sponsorId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "introduction_id")
+    private Introduction introduction;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Builder
+    public Sponsor(Introduction introduction, String imageUrl) {
+        this.introduction = introduction;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/ActivityRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/ActivityRepository.java
@@ -1,9 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
+import com.kusitms.website.domain.introduction.entity.Activity;
 import com.kusitms.website.domain.introduction.entity.Introduction;
-import com.kusitms.website.domain.introduction.entity.ManageTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManageTeamRepository extends JpaRepository<ManageTeam, Long> {
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
     void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/ExpertLectureRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/ExpertLectureRepository.java
@@ -1,7 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
 import com.kusitms.website.domain.introduction.entity.ExpertLecture;
+import com.kusitms.website.domain.introduction.entity.Introduction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExpertLectureRepository extends JpaRepository<ExpertLecture, Long> {
+    void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/IntroMeetupImageRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/IntroMeetupImageRepository.java
@@ -1,9 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
+import com.kusitms.website.domain.introduction.entity.IntroMeetupImage;
 import com.kusitms.website.domain.introduction.entity.Introduction;
-import com.kusitms.website.domain.introduction.entity.ManageTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManageTeamRepository extends JpaRepository<ManageTeam, Long> {
+public interface IntroMeetupImageRepository extends JpaRepository<IntroMeetupImage, Long> {
     void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/OBLectureRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/OBLectureRepository.java
@@ -1,7 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
+import com.kusitms.website.domain.introduction.entity.Introduction;
 import com.kusitms.website.domain.introduction.entity.OBLecture;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OBLectureRepository extends JpaRepository<OBLecture, Long> {
+    void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/PartnerLogoRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/PartnerLogoRepository.java
@@ -1,9 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
 import com.kusitms.website.domain.introduction.entity.Introduction;
-import com.kusitms.website.domain.introduction.entity.ManageTeam;
+import com.kusitms.website.domain.introduction.entity.PartnerLogo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManageTeamRepository extends JpaRepository<ManageTeam, Long> {
+public interface PartnerLogoRepository extends JpaRepository<PartnerLogo, Long> {
     void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/introduction/repository/SponsorRepository.java
+++ b/src/main/java/com/kusitms/website/domain/introduction/repository/SponsorRepository.java
@@ -1,9 +1,9 @@
 package com.kusitms.website.domain.introduction.repository;
 
 import com.kusitms.website.domain.introduction.entity.Introduction;
-import com.kusitms.website.domain.introduction.entity.ManageTeam;
+import com.kusitms.website.domain.introduction.entity.Sponsor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManageTeamRepository extends JpaRepository<ManageTeam, Long> {
+public interface SponsorRepository extends JpaRepository<Sponsor, Long> {
     void deleteByIntroduction(Introduction introduction);
 }

--- a/src/main/java/com/kusitms/website/domain/project/dto/request/MeetupRequest.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/request/MeetupRequest.java
@@ -43,6 +43,9 @@ public class MeetupRequest {
     @Schema(description = "프로젝트 결과물 URL", example = "https://github.com/kusitms-com")
     private String appUrl;
 
+    @Schema(description = "비핸스 URL", example = "https://www.behance.net/")
+    private String behanceUrl;
+
     @Schema(description = "프로젝트 시작 날짜", example = "2022-02-12")
     private String startDate;
 
@@ -86,6 +89,7 @@ public class MeetupRequest {
                 .instagramUrl(request.getInstagramUrl())
                 .githubUrl(request.getGithubUrl())
                 .appUrl(request.getAppUrl())
+                .behanceUrl(request.getBehanceUrl())
                 .startDate(LocalDate.parse(request.getStartDate(), DateTimeFormatter.ISO_DATE))
                 .endDate(LocalDate.parse(request.getEndDate(), DateTimeFormatter.ISO_DATE))
                 .logoUrl(logoUrl)

--- a/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupDetailResponse.java
@@ -114,6 +114,7 @@ public class MeetupDetailResponse {
         this.posterUrl = s3Url + meetup.getPosterUrl();
         this.logoUrl = s3Url + meetup.getLogoUrl();
         this.oneLineIntro = meetup.getOneLineIntro();
+        this.behanceUrl = meetup.getBehanceUrl();
         this.instagramUrl = meetup.getInstagramUrl();
         this.githubUrl = meetup.getGithubUrl();
         this.appUrl = meetup.getAppUrl();

--- a/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupTeamResponse.java
+++ b/src/main/java/com/kusitms/website/domain/project/dto/response/MeetupTeamResponse.java
@@ -2,6 +2,7 @@ package com.kusitms.website.domain.project.dto.response;
 
 import com.kusitms.website.domain.admin.entity.TMPMeetupTeam;
 import com.kusitms.website.domain.project.entity.MeetupTeam;
+import com.kusitms.website.domain.project.entity.Team;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -29,123 +30,55 @@ public class MeetupTeamResponse {
 
     public MeetupTeamResponse(List<MeetupTeam> team, String name) {
         this.name = name;
-        getMember(team);
+        for (MeetupTeam t : team) {
+            addMember(t.getTeam(), t.getName());
+        }
+        sortAll();
     }
 
     public MeetupTeamResponse(String name, List<TMPMeetupTeam> team) {
         this.name = name;
-        getTMPMember(team);
+        for (TMPMeetupTeam t : team) {
+            addMember(t.getTeam(), t.getName());
+        }
+        sortAll();
     }
 
-    private void getMember(List<MeetupTeam> team) {
-        for(MeetupTeam t : team) {
-            switch(t.getTeam()) {
-                case PLANNER:
-                    if(planner == null) {
-                        planner = new ArrayList<>();
-                    }
-                    planner.add(t.getName());
-                    break;
-                case DESIGNER:
-                    if(designer == null) {
-                        designer = new ArrayList<>();
-                    }
-                    designer.add(t.getName());
-                    break;
-                case FRONTEND:
-                    if(frontend == null) {
-                        frontend = new ArrayList<>();
-                    }
-                    frontend.add(t.getName());
-                    break;
-                case BACKEND:
-                    if(backend == null) {
-                        backend = new ArrayList<>();
-                    }
-                    backend.add(t.getName());
-                    break;
-                case IOS:
-                    if(ios == null) {
-                        ios = new ArrayList<>();
-                    }
-                    ios.add(t.getName());
-                    break;
-                case ANDROID:
-                    if(aos == null) {
-                        aos = new ArrayList<>();
-                    }
-                    aos.add(t.getName());
-                    break;
-            }
-        }
-
-        Collections.sort(planner);
-        Collections.sort(designer);
-        Collections.sort(backend);
-        if(frontend != null) {
-            Collections.sort(frontend);
-        }
-        if(ios != null) {
-            Collections.sort(ios);
-        }
-        if(aos != null) {
-            Collections.sort(aos);
+    private void addMember(Team team, String memberName) {
+        switch (team) {
+            case PLANNER:
+                if (planner == null) planner = new ArrayList<>();
+                planner.add(memberName);
+                break;
+            case DESIGNER:
+                if (designer == null) designer = new ArrayList<>();
+                designer.add(memberName);
+                break;
+            case FRONTEND:
+                if (frontend == null) frontend = new ArrayList<>();
+                frontend.add(memberName);
+                break;
+            case BACKEND:
+                if (backend == null) backend = new ArrayList<>();
+                backend.add(memberName);
+                break;
+            case IOS:
+                if (ios == null) ios = new ArrayList<>();
+                ios.add(memberName);
+                break;
+            case ANDROID:
+                if (aos == null) aos = new ArrayList<>();
+                aos.add(memberName);
+                break;
         }
     }
 
-    private void getTMPMember(List<TMPMeetupTeam> team) {
-        for(TMPMeetupTeam t : team) {
-            switch(t.getTeam()) {
-                case PLANNER:
-                    if(planner == null) {
-                        planner = new ArrayList<>();
-                    }
-                    planner.add(t.getName());
-                    break;
-                case DESIGNER:
-                    if(designer == null) {
-                        designer = new ArrayList<>();
-                    }
-                    designer.add(t.getName());
-                    break;
-                case FRONTEND:
-                    if(frontend == null) {
-                        frontend = new ArrayList<>();
-                    }
-                    frontend.add(t.getName());
-                    break;
-                case BACKEND:
-                    if(backend == null) {
-                        backend = new ArrayList<>();
-                    }
-                    backend.add(t.getName());
-                    break;
-                case IOS:
-                    if(ios == null) {
-                        ios = new ArrayList<>();
-                    }
-                    ios.add(t.getName());
-                    break;
-                case ANDROID:
-                    if(aos == null) {
-                        aos = new ArrayList<>();
-                    }
-                    aos.add(t.getName());
-                    break;
-            }
-        }
-
-        Collections.sort(planner);
-        Collections.sort(designer);
-        Collections.sort(backend);
-        if(frontend != null) {
-            Collections.sort(frontend);
-        }
-        if(ios != null) {
-            Collections.sort(ios);
-        }
-        if(aos != null) {
-            Collections.sort(aos);
-        }
+    private void sortAll() {
+        if (planner != null) Collections.sort(planner);
+        if (designer != null) Collections.sort(designer);
+        if (frontend != null) Collections.sort(frontend);
+        if (backend != null) Collections.sort(backend);
+        if (ios != null) Collections.sort(ios);
+        if (aos != null) Collections.sort(aos);
     }
 }


### PR DESCRIPTION
### 이슈 번호
https://github.com/kusitms-com/api.kusitms.com/issues/42

### 💡 작업 내용
- TMPMeetupProject 엔티티에 behanceUrl 필드 추가
- 밋업 등록/수정 요청에 behanceUrl 반영
- 밋업 수정 시 이미지 미변경이면 기존 URL 유지 (uploadOrKeep)
- MeetupTeamResponse 팀원 분류 로직 리팩토링 (중복 switch 제거)

### 🎸 기타
기존 #24에서 조회 응답에만 비핸스 링크를 추가했으나, 어드민 등록/수정 흐름에는 미반영 상태였음