### PR TITLE
feat: 회원 인증 및 관리자 승인 기능 구현 (#45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/kusitms/website/WebsiteApplication.java
+++ b/src/main/java/com/kusitms/website/WebsiteApplication.java
@@ -2,7 +2,9 @@ package com.kusitms.website;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class WebsiteApplication {
 

--- a/src/main/java/com/kusitms/website/domain/admin/AdminController.java
+++ b/src/main/java/com/kusitms/website/domain/admin/AdminController.java
@@ -1,5 +1,6 @@
 package com.kusitms.website.domain.admin;
 
+import com.kusitms.website.domain.admin.dto.response.PendingMemberResponse;
 import com.kusitms.website.domain.introduction.IntroService;
 import com.kusitms.website.domain.introduction.dto.request.IntroRequest;
 import com.kusitms.website.domain.blog.dto.request.BlogReviewRequest;
@@ -18,9 +19,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,6 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 public class AdminController {
     private final IntroService introService;
     private final AdminService adminService;
+    private final MemberAdminService memberAdminService;
     private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/admin/introductions")
@@ -249,6 +254,33 @@ public class AdminController {
     })
     public ResponseEntity<BaseResponse> deleteBlogReview(@PathVariable("id") Long blogReviewId) {
         adminService.deleteBlogReview(blogReviewId);
+        return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @GetMapping("/admin/members/pending")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "승인 대기 회원 목록 조회", description = "가입 승인 대기 중인 회원 목록을 조회합니다.")
+    public ResponseEntity<BaseResponse<List<PendingMemberResponse>>> getPendingMembers() {
+        return ResponseEntity.ok(new BaseResponse<>(memberAdminService.getPendingMembers()));
+    }
+
+    @PostMapping("/admin/members/{userId}/approve")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "회원 가입 승인", description = "대기 중인 회원의 가입을 승인합니다.")
+    public ResponseEntity<BaseResponse> approveMember(
+            @PathVariable Long userId
+    ) {
+        memberAdminService.approveMember(userId);
+        return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @PostMapping("/admin/members/{userId}/reject")
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "회원 가입 반려", description = "대기 중인 회원의 가입을 반려하고 계정을 삭제합니다.")
+    public ResponseEntity<BaseResponse> rejectMember(
+            @PathVariable Long userId
+    ) {
+        memberAdminService.rejectMember(userId);
         return ResponseEntity.ok(new BaseResponse());
     }
 }

--- a/src/main/java/com/kusitms/website/domain/admin/MemberAdminService.java
+++ b/src/main/java/com/kusitms/website/domain/admin/MemberAdminService.java
@@ -1,0 +1,61 @@
+package com.kusitms.website.domain.admin;
+
+import com.kusitms.website.domain.admin.dto.response.PendingMemberResponse;
+import com.kusitms.website.domain.email.service.MailService;
+import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.MemberRepository;
+import com.kusitms.website.domain.user.MemberStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAdminService {
+
+    private final MemberRepository memberRepository;
+    private final MailService mailService;
+
+    public List<PendingMemberResponse> getPendingMembers() {
+        return memberRepository.findAllByStatus(MemberStatus.PENDING).stream()
+                .map(PendingMemberResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void approveMember(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        if (member.getStatus() != MemberStatus.PENDING) {
+            throw new IllegalArgumentException("승인 대기 상태가 아닌 회원입니다.");
+        }
+
+        member.approve();
+
+        if (member.getEmail() != null && !member.getEmail().isBlank()) {
+            mailService.sendApprovalEmail(member.getEmail(), member.getName());
+        }
+    }
+
+    @Transactional
+    public void rejectMember(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        if (member.getStatus() != MemberStatus.PENDING) {
+            throw new IllegalArgumentException("승인 대기 상태가 아닌 회원입니다.");
+        }
+
+        String name = member.getName();
+        String email = member.getEmail();
+        memberRepository.delete(member);
+
+        if (email != null && !email.isBlank()) {
+            mailService.sendRejectionEmail(email, name);
+        }
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/admin/dto/response/PendingMemberResponse.java
+++ b/src/main/java/com/kusitms/website/domain/admin/dto/response/PendingMemberResponse.java
@@ -1,0 +1,48 @@
+package com.kusitms.website.domain.admin.dto.response;
+
+import com.kusitms.website.domain.user.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "승인 대기 회원 응답")
+public class PendingMemberResponse {
+    @Schema(description = "회원 PK")
+    private Long userId;
+
+    @Schema(description = "아이디")
+    private String id;
+
+    @Schema(description = "이름")
+    private String name;
+
+    @Schema(description = "휴대폰 번호")
+    private String phone;
+
+    @Schema(description = "활동 기수")
+    private Integer cardinal;
+
+    @Schema(description = "파트")
+    private String part;
+
+    @Schema(description = "프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "수료증 이미지 URL")
+    private String certificateImageUrl;
+
+    public static PendingMemberResponse from(Member member) {
+        return new PendingMemberResponse(
+                member.getUserId(),
+                member.getId(),
+                member.getName(),
+                member.getPhone(),
+                member.getCardinal(),
+                member.getPart().name(),
+                member.getProfileImageUrl(),
+                member.getCertificateImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/email/service/MailService.java
+++ b/src/main/java/com/kusitms/website/domain/email/service/MailService.java
@@ -1,0 +1,99 @@
+package com.kusitms.website.domain.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import javax.mail.internet.MimeMessage;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private static final String BANNER_URL = "https://kusitms-bucket.s3.ap-northeast-2.amazonaws.com/meetup/OG/456ed518-7489-4106-9d33-94c491ef358732__OG_.png";
+    private static final String BRAND_COLOR = "#4A3AFF";
+
+    private final JavaMailSender mailSender;
+
+    @Async
+    public void sendApprovalEmail(String toEmail, String name) {
+        String subject = "[큐시즘] 회원가입이 승인되었습니다";
+        String html = buildEmail(name,
+                "회원가입 승인 완료",
+                "큐시즘 회원가입이 승인되었습니다.<br>지금 바로 로그인하여 서비스를 이용하실 수 있습니다.",
+                "로그인하기",
+                "https://kusitms.com");
+        sendHtmlEmail(toEmail, subject, html);
+    }
+
+    @Async
+    public void sendRejectionEmail(String toEmail, String name) {
+        String subject = "[큐시즘] 회원가입 신청이 반려되었습니다";
+        String html = buildEmail(name,
+                "회원가입 반려 안내",
+                "큐시즘 회원가입 신청이 반려되었습니다.<br>문의 사항이 있으시면 운영진에게 연락해 주세요.",
+                null, null);
+        sendHtmlEmail(toEmail, subject, html);
+    }
+
+    private void sendHtmlEmail(String toEmail, String subject, String html) {
+        try {
+            MimeMessage mime = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mime, "UTF-8");
+            helper.setTo(toEmail);
+            helper.setSubject(subject);
+            helper.setText(html, true);
+            mailSender.send(mime);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패: {}", toEmail, e);
+        }
+    }
+
+    private String buildEmail(String name, String title, String body, String buttonText, String buttonUrl) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<!DOCTYPE html><html><head><meta charset='UTF-8'></head>");
+        sb.append("<body style='margin:0;padding:0;background-color:#f4f4f7;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;'>");
+        sb.append("<table width='100%' cellpadding='0' cellspacing='0' style='background-color:#f4f4f7;padding:40px 0;'><tr><td align='center'>");
+        sb.append("<table width='600' cellpadding='0' cellspacing='0' style='background-color:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.08);'>");
+
+        // Banner
+        sb.append("<tr><td style='padding:0;'>");
+        sb.append("<img src='").append(BANNER_URL).append("' width='600' style='display:block;width:100%;height:auto;' alt='KUSITMS' />");
+        sb.append("</td></tr>");
+
+        // Title
+        sb.append("<tr><td style='padding:32px 40px 0 40px;'>");
+        sb.append("<h1 style='margin:0;font-size:22px;color:#1a1a1a;'>").append(title).append("</h1>");
+        sb.append("</td></tr>");
+
+        // Body
+        sb.append("<tr><td style='padding:16px 40px 0 40px;'>");
+        sb.append("<p style='margin:0;font-size:15px;line-height:1.7;color:#555555;'>");
+        sb.append(name).append("님, 안녕하세요.<br><br>");
+        sb.append(body);
+        sb.append("</p></td></tr>");
+
+        // Button
+        if (buttonText != null && buttonUrl != null) {
+            sb.append("<tr><td style='padding:28px 40px 0 40px;'>");
+            sb.append("<a href='").append(buttonUrl).append("' style='display:inline-block;padding:12px 32px;background-color:").append(BRAND_COLOR);
+            sb.append(";color:#ffffff;text-decoration:none;border-radius:8px;font-size:14px;font-weight:600;'>").append(buttonText).append("</a>");
+            sb.append("</td></tr>");
+        }
+
+        // Footer
+        sb.append("<tr><td style='padding:32px 40px;'>");
+        sb.append("<hr style='border:none;border-top:1px solid #eeeeee;margin:0 0 20px 0;' />");
+        sb.append("<p style='margin:0;font-size:12px;color:#999999;line-height:1.6;'>");
+        sb.append("본 메일은 큐시즘에서 발송한 자동 알림 메일입니다.<br>");
+        sb.append("© KUSITMS. All rights reserved.");
+        sb.append("</p></td></tr>");
+
+        sb.append("</table></td></tr></table></body></html>");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/CurrentCardinal.java
+++ b/src/main/java/com/kusitms/website/domain/user/CurrentCardinal.java
@@ -1,0 +1,25 @@
+package com.kusitms.website.domain.user;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CurrentCardinal {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer cardinal;
+
+    public CurrentCardinal(Integer cardinal) {
+        this.cardinal = cardinal;
+    }
+
+    public void updateCardinal(Integer cardinal) {
+        this.cardinal = cardinal;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/CurrentCardinalRepository.java
+++ b/src/main/java/com/kusitms/website/domain/user/CurrentCardinalRepository.java
@@ -1,0 +1,6 @@
+package com.kusitms.website.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CurrentCardinalRepository extends JpaRepository<CurrentCardinal, Long> {
+}

--- a/src/main/java/com/kusitms/website/domain/user/Member.java
+++ b/src/main/java/com/kusitms/website/domain/user/Member.java
@@ -2,28 +2,82 @@ package com.kusitms.website.domain.user;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Member {
     @Id
     @Column(name = "user_id", nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    @Column(unique = true)
     private String id;
 
     private String password;
 
+    private String name;
+
+    private String phone;
+
+    private Integer cardinal;
+
+    @Enumerated(EnumType.STRING)
+    private Part part;
+
+    private String profileImageUrl;
+
+    private String certificateImageUrl;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_role")
+    private MemberRole role;
+
+    private String refreshToken;
+
+    private LocalDateTime createdAt;
+
     @Builder
-    public Member(String id, String password) {
+    public Member(String id, String password, String name, String phone,
+                  Integer cardinal, Part part, String profileImageUrl,
+                  String certificateImageUrl, String email, MemberStatus status, MemberRole role) {
         this.id = id;
         this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.cardinal = cardinal;
+        this.part = part;
+        this.profileImageUrl = profileImageUrl;
+        this.certificateImageUrl = certificateImageUrl;
+        this.email = email;
+        this.status = status;
+        this.role = role;
+        this.createdAt = LocalDateTime.now();
     }
 
-    public Member() {
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 
+    public void clearRefreshToken() {
+        this.refreshToken = null;
+    }
+
+    public void updateRole(MemberRole role) {
+        this.role = role;
+    }
+
+    public void approve() {
+        this.status = MemberStatus.APPROVED;
     }
 }

--- a/src/main/java/com/kusitms/website/domain/user/MemberController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberController.java
@@ -2,32 +2,66 @@ package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.user.dto.request.SignInRequest;
 import com.kusitms.website.domain.user.dto.request.SignUpRequest;
+import com.kusitms.website.domain.user.dto.response.CurrentCardinalResponse;
+import com.kusitms.website.domain.user.dto.response.SignInResponse;
 import com.kusitms.website.global.common.BaseResponse;
-import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "인증 API")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @Hidden
-    @PostMapping("/signup")
-    public ResponseEntity<BaseResponse> signup (@RequestBody SignUpRequest request) {
-        Long userId = memberService.save(request);
+    @Operation(summary = "회원가입")
+    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse> signup(
+            @RequestPart("signUpRequest") @Valid SignUpRequest request,
+            @RequestPart("profileImage") MultipartFile profileImage,
+            @RequestPart(value = "certificateImage", required = false) MultipartFile certificateImage
+    ) {
+        Long userId = memberService.signup(request, profileImage, certificateImage);
         return ResponseEntity.ok(new BaseResponse(userId));
     }
 
+    @Operation(summary = "로그인")
     @PostMapping("/signin")
-    public ResponseEntity<BaseResponse> signin (@RequestBody SignInRequest request) {
-        String token = memberService.signin(request);
-        return ResponseEntity.ok(new BaseResponse(token));
+    public ResponseEntity<BaseResponse<SignInResponse>> signin(@RequestBody SignInRequest request) {
+        SignInResponse response = memberService.signin(request);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "아이디 중복 체크")
+    @GetMapping("/check-id")
+    public ResponseEntity<BaseResponse<Map<String, Object>>> checkId(@RequestParam String id) {
+        Map<String, Object> result = memberService.checkIdDuplicate(id);
+        return ResponseEntity.ok(new BaseResponse<>(result));
+    }
+
+    @Operation(summary = "토큰 갱신")
+    @PostMapping("/refresh")
+    public ResponseEntity<BaseResponse<SignInResponse>> refresh(@RequestBody Map<String, String> request) {
+        String refreshToken = request.get("refreshToken");
+        SignInResponse response = memberService.refreshToken(refreshToken);
+        return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    @Operation(summary = "현재 기수 조회")
+    @GetMapping("/current-cardinal")
+    public ResponseEntity<BaseResponse<CurrentCardinalResponse>> getCurrentCardinal() {
+        CurrentCardinalResponse response = memberService.getCurrentCardinal();
+        return ResponseEntity.ok(new BaseResponse<>(response));
     }
 }

--- a/src/main/java/com/kusitms/website/domain/user/MemberRepository.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberRepository.java
@@ -2,8 +2,17 @@ package com.kusitms.website.domain.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByIdAndStatus(String id, MemberStatus status);
+
     Optional<Member> findById(String id);
+
+    boolean existsById(String id);
+
+    List<Member> findAllByStatus(MemberStatus status);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/kusitms/website/domain/user/MemberRole.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberRole.java
@@ -1,0 +1,7 @@
+package com.kusitms.website.domain.user;
+
+public enum MemberRole {
+    YB,
+    OB,
+    ADMIN
+}

--- a/src/main/java/com/kusitms/website/domain/user/MemberService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberService.java
@@ -1,50 +1,230 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.SignInRequest;
 import com.kusitms.website.domain.user.dto.request.SignUpRequest;
+import com.kusitms.website.domain.user.dto.response.CurrentCardinalResponse;
+import com.kusitms.website.domain.user.dto.response.SignInResponse;
 import com.kusitms.website.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,}$");
+    private static final Pattern PHONE_PATTERN =
+            Pattern.compile("^010\\d{8}$");
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
+
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-
     private final MemberRepository memberRepository;
+    private final CurrentCardinalRepository currentCardinalRepository;
+    private final S3Service s3Service;
 
-    public Long save(SignUpRequest request) {
+    @Transactional
+    public Long signup(SignUpRequest request, MultipartFile profileImage, MultipartFile certificateImage) {
+        validateSignUpRequest(request, certificateImage);
 
-        // pw 암호화
-        String encodingPassword = bCryptPasswordEncoder.encode(request.getPassword());
+        if (memberRepository.existsById(request.getId())) {
+            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+        }
 
-        Member user = SignUpRequest.from(request, encodingPassword);
+        validateImageFile(profileImage, "프로필 사진");
+        if (certificateImage != null && !certificateImage.isEmpty()) {
+            validateImageFile(certificateImage, "수료증");
+        }
 
-        memberRepository.save(user);
-        return user.getUserId();
+        Integer currentCardinal = getCurrentCardinalValue();
+        MemberRole role = request.getCardinal() >= currentCardinal ? MemberRole.YB : MemberRole.OB;
+
+        String profileImageUrl = s3Service.uploadFile(profileImage, "profile");
+        String certificateImageUrl = null;
+        if (certificateImage != null && !certificateImage.isEmpty()) {
+            certificateImageUrl = s3Service.uploadFile(certificateImage, "certificate");
+        }
+
+        String encodedPassword = bCryptPasswordEncoder.encode(request.getPassword());
+
+        Member member = Member.builder()
+                .id(request.getId())
+                .password(encodedPassword)
+                .name(request.getName())
+                .phone(normalizePhone(request.getPhone()))
+                .cardinal(request.getCardinal())
+                .part(Part.valueOf(request.getPart()))
+                .profileImageUrl(profileImageUrl)
+                .certificateImageUrl(certificateImageUrl)
+                .email(request.getEmail())
+                .status(MemberStatus.PENDING)
+                .role(role)
+                .build();
+
+        memberRepository.save(member);
+        return member.getUserId();
     }
 
-    public String signin(SignInRequest request) {
+    @Transactional
+    public SignInResponse signin(SignInRequest request) {
+        Member member = memberRepository.findById(request.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
 
-        Member user = memberRepository.findById(request.getId())
-                .orElseThrow(() -> new IllegalArgumentException("가입된 아이디가 아닙니다."));
+        if (member.getStatus() == MemberStatus.PENDING) {
+            throw new IllegalArgumentException("관리자 승인 대기 중인 계정입니다. 승인 후 로그인해 주세요.");
+        }
 
-        // 패스워드 일치 여부 확인
-        passwordMustBeSame(request.getPassword(), user.getPassword());
+        if (!bCryptPasswordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
+        }
 
-        // user pk로 토큰 생성
-        String token = jwtTokenProvider.makeJwtToken(user.getUserId());
+        // 기수 변경 시 역할 재판별
+        MemberRole role = member.getRole() != null ? member.getRole() : MemberRole.OB;
+        if (member.getCardinal() != null) {
+            Integer currentCardinal = getCurrentCardinalValue();
+            role = member.getCardinal() >= currentCardinal ? MemberRole.YB : MemberRole.OB;
+            if (member.getRole() != role) {
+                member.updateRole(role);
+            }
+        }
 
-        return token;
+        String accessToken = jwtTokenProvider.makeJwtToken(member.getUserId());
+        String refreshToken = jwtTokenProvider.makeRefreshToken(member.getUserId());
+        member.updateRefreshToken(hashToken(refreshToken));
+
+        String redirectPath = role == MemberRole.YB ? "/mypage" : "/mypage/ob/profile";
+
+        return new SignInResponse(accessToken, refreshToken, role, redirectPath);
     }
 
-    private void passwordMustBeSame(String requestPassword, String password) {
-        if (!bCryptPasswordEncoder.matches(requestPassword, password)) {
-            throw new IllegalArgumentException();
+    public Map<String, Object> checkIdDuplicate(String id) {
+        if (id == null || id.isBlank()) {
+            throw new IllegalArgumentException("아이디를 먼저 입력해 주세요.");
+        }
+        boolean isDuplicate = memberRepository.existsById(id);
+        String message = isDuplicate ? "이미 사용 중인 아이디입니다." : "사용 가능한 아이디입니다.";
+        return Map.of("available", !isDuplicate, "message", message);
+    }
+
+    @Transactional
+    public SignInResponse refreshToken(String refreshToken) {
+        String hashedToken = hashToken(refreshToken);
+        Member member = memberRepository.findByRefreshToken(hashedToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다."));
+
+        try {
+            jwtTokenProvider.validateToken(refreshToken);
+        } catch (Exception e) {
+            member.clearRefreshToken();
+            throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요.");
+        }
+
+        String newAccessToken = jwtTokenProvider.makeJwtToken(member.getUserId());
+        String newRefreshToken = jwtTokenProvider.makeRefreshToken(member.getUserId());
+        member.updateRefreshToken(hashToken(newRefreshToken));
+
+        String redirectPath = member.getRole() == MemberRole.YB ? "/mypage" : "/mypage/ob/profile";
+
+        return new SignInResponse(newAccessToken, newRefreshToken, member.getRole(), redirectPath);
+    }
+
+    public CurrentCardinalResponse getCurrentCardinal() {
+        Integer cardinal = getCurrentCardinalValue();
+        return new CurrentCardinalResponse(cardinal);
+    }
+
+    public List<Member> getPendingMembers() {
+        return memberRepository.findAllByStatus(MemberStatus.PENDING);
+    }
+
+    private Integer getCurrentCardinalValue() {
+        return currentCardinalRepository.findById(1L)
+                .map(CurrentCardinal::getCardinal)
+                .orElse(33);
+    }
+
+    private void validateSignUpRequest(SignUpRequest request, MultipartFile certificateImage) {
+        if (request.getId() == null || request.getId().isBlank()) {
+            throw new IllegalArgumentException("아이디를 입력해 주세요.");
+        }
+        if (request.getPassword() == null || !PASSWORD_PATTERN.matcher(request.getPassword()).matches()) {
+            throw new IllegalArgumentException("영문, 숫자, 특수문자를 포함해 8자 이상이어야 합니다.");
+        }
+        if (!request.getPassword().equals(request.getPasswordConfirm())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+        if (request.getName() == null || request.getName().isBlank()) {
+            throw new IllegalArgumentException("이름을 입력해 주세요.");
+        }
+        if (request.getPhone() == null || !PHONE_PATTERN.matcher(normalizePhone(request.getPhone())).matches()) {
+            throw new IllegalArgumentException("올바른 휴대폰 번호를 입력해 주세요.");
+        }
+        if (request.getCardinal() == null) {
+            throw new IllegalArgumentException("활동 기수를 선택해 주세요.");
+        }
+        if (request.getPart() == null || request.getPart().isBlank()) {
+            throw new IllegalArgumentException("파트를 선택해 주세요.");
+        }
+        try {
+            Part.valueOf(request.getPart());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("파트를 선택해 주세요.");
+        }
+
+        if (request.getEmail() == null || request.getEmail().isBlank()) {
+            throw new IllegalArgumentException("이메일을 입력해 주세요.");
+        }
+
+        if (request.getCardinal() <= 33 && (certificateImage == null || certificateImage.isEmpty())) {
+            throw new IllegalArgumentException("33기 이하 회원은 수료증을 업로드해 주세요.");
         }
     }
 
+    private void validateImageFile(MultipartFile file, String fieldName) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + "을(를) 업로드해 주세요.");
+        }
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("10MB 이하의 이미지만 업로드 가능합니다.");
+        }
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null) {
+            throw new IllegalArgumentException("이미지 파일(jpg, png)만 업로드 가능합니다.");
+        }
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("이미지 파일(jpg, png)만 업로드 가능합니다.");
+        }
+    }
+
+    private String normalizePhone(String phone) {
+        return phone.replaceAll("[^0-9]", "");
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/user/MemberStatus.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.kusitms.website.domain.user;
+
+public enum MemberStatus {
+    PENDING,
+    APPROVED
+}

--- a/src/main/java/com/kusitms/website/domain/user/Part.java
+++ b/src/main/java/com/kusitms/website/domain/user/Part.java
@@ -1,0 +1,8 @@
+package com.kusitms.website.domain.user;
+
+public enum Part {
+    PLANNER,
+    DESIGNER,
+    FRONTEND,
+    BACKEND
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/SignUpRequest.java
@@ -1,18 +1,34 @@
 package com.kusitms.website.domain.user.dto.request;
 
-import com.kusitms.website.domain.user.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
+@Schema(description = "회원가입 요청")
 public class SignUpRequest {
-
+    @Schema(description = "아이디")
     private String id;
+
+    @Schema(description = "비밀번호")
     private String password;
 
-    public static Member from(SignUpRequest request, String encodingPassword) {
-        return Member.builder()
-                .id(request.getId())
-                .password(encodingPassword)
-                .build();
-    }
+    @Schema(description = "비밀번호 확인")
+    private String passwordConfirm;
+
+    @Schema(description = "이름")
+    private String name;
+
+    @Schema(description = "휴대폰 번호")
+    private String phone;
+
+    @Schema(description = "활동 기수")
+    private Integer cardinal;
+
+    @Schema(description = "파트 (PLANNER, DESIGNER, FRONTEND, BACKEND)")
+    private String part;
+
+    @Schema(description = "이메일")
+    private String email;
 }

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/CurrentCardinalResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/CurrentCardinalResponse.java
@@ -1,0 +1,13 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "현재 기수 응답")
+public class CurrentCardinalResponse {
+    @Schema(description = "현재 활동 기수")
+    private Integer currentCardinal;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/SignInResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/SignInResponse.java
@@ -1,0 +1,23 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.user.MemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "로그인 응답")
+public class SignInResponse {
+    @Schema(description = "Access Token")
+    private String accessToken;
+
+    @Schema(description = "Refresh Token")
+    private String refreshToken;
+
+    @Schema(description = "사용자 역할 (YB/OB)")
+    private MemberRole role;
+
+    @Schema(description = "리다이렉트 경로")
+    private String redirectPath;
+}

--- a/src/main/java/com/kusitms/website/global/auth/UserPrincipal.java
+++ b/src/main/java/com/kusitms/website/global/auth/UserPrincipal.java
@@ -1,34 +1,47 @@
 package com.kusitms.website.global.auth;
 
 import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.MemberRole;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @Getter
 public class UserPrincipal implements UserDetails {
     private Long pk;
     private String id;
     private String paswword;
+    private Collection<? extends GrantedAuthority> authorities;
 
-    public UserPrincipal(Long pk, String id) {
+    public UserPrincipal(Long pk, String id, Collection<? extends GrantedAuthority> authorities) {
         this.pk = pk;
         this.id = id;
+        this.authorities = authorities;
     }
 
 
     public static UserPrincipal create(Member user) {
+        List<GrantedAuthority> authorities;
+        if (user.getRole() == MemberRole.ADMIN) {
+            authorities = List.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        } else {
+            authorities = Collections.emptyList();
+        }
         return new UserPrincipal(
                 user.getUserId(),
-                user.getId()
+                user.getId(),
+                authorities
         );
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return authorities;
     }
 
     @Override

--- a/src/main/java/com/kusitms/website/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kusitms/website/global/auth/jwt/JwtTokenProvider.java
@@ -22,12 +22,12 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    // 1시간
-    private final long TOKEN_VALID_MILISECOND = 1000L * 60 * 60;
+    private static final long ACCESS_TOKEN_VALIDITY = 1000L * 60 * 60; // 1시간
+    private static final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7; // 7일
 
     private final UserDetailsService userDetailsService;
 
-    @Value("spring.jwt.secretkey")
+    @Value("${spring.jwt.secretkey}")
     private String secretKey;
 
     @PostConstruct
@@ -36,24 +36,37 @@ public class JwtTokenProvider {
     }
 
     public String makeJwtToken(Long userId) {
+        return createToken(userId, ACCESS_TOKEN_VALIDITY, "access");
+    }
+
+    public String makeRefreshToken(Long userId) {
+        return createToken(userId, REFRESH_TOKEN_VALIDITY, "refresh");
+    }
+
+    private String createToken(Long userId, long validity, String tokenType) {
         Claims claims = Jwts.claims().setSubject(Long.toString(userId));
+        claims.put("type", tokenType);
         Date now = new Date();
 
         return Jwts.builder()
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + TOKEN_VALID_MILISECOND))
+                .setExpiration(new Date(now.getTime() + validity))
                 .setClaims(claims)
                 .signWith(SignatureAlgorithm.HS512, secretKey)
                 .compact();
     }
 
-    // 인증 성공시 SecurityContextHolder에 저장할 Authentication 객체 생성
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(this.getUserPk(token)));
+        Claims claims = Jwts.parser().setSigningKey(secretKey)
+                .parseClaimsJws(token).getBody();
+        String tokenType = claims.get("type", String.class);
+        if (!"access".equals(tokenType)) {
+            throw new IllegalArgumentException("액세스 토큰이 아닙니다.");
+        }
+        UserDetails userDetails = userDetailsService.loadUserByUsername(claims.getSubject());
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    // Jwt Token에서 User PK 추출
     public Long getUserPk(String token) {
         Claims claims = Jwts.parser().setSigningKey(secretKey)
                 .parseClaimsJws(token).getBody();
@@ -69,7 +82,6 @@ public class JwtTokenProvider {
         return null;
     }
 
-    // Jwt Token의 유효성 및 만료 기간 검사
     public boolean validateToken(String jwtToken) {
         Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
         return true;

--- a/src/main/java/com/kusitms/website/global/config/OpenApiConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/OpenApiConfig.java
@@ -3,6 +3,8 @@ package com.kusitms.website.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,12 +12,22 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
+        String securitySchemeName = "Bearer Authentication";
+
         Info info = new Info()
                 .title("KUSTIMS 공식 홈페이지 API Document")
                 .version("v0.0.1")
                 .description("KUSITMS 공식 홈페이지 프로젝트의 API 명세서");
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components()
+                        .addSecuritySchemes(securitySchemeName, securityScheme))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
                 .info(info);
     }
 }

--- a/src/main/java/com/kusitms/website/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.kusitms.website.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -21,6 +22,7 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/kusitms/website/global/config/WebConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/WebConfig.java
@@ -10,7 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("*")
-                .allowedMethods("GET")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
                 .maxAge(3000);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ springdoc.cache.disabled=true
 # Mail
 spring.mail.host=${MAIL_HOST:smtp.gmail.com}
 spring.mail.port=${MAIL_PORT:587}
-spring.mail.username=${MAIL_USERNAME}
-spring.mail.password=${MAIL_PASSWORD}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,11 @@ springdoc.swagger-ui.operations-sorter=alpha
 springdoc.api-docs.path=/api-docs/json
 springdoc.api-docs.groups.enabled=true
 springdoc.cache.disabled=true
+
+# Mail
+spring.mail.host=${MAIL_HOST:smtp.gmail.com}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,3 +12,21 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=100
   # multipart
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=100MB
+
+# AWS
+cloud.aws.credentials.access-key=test
+cloud.aws.credentials.secret-key=test
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=test
+cloud.aws.stack.auto=false
+cloud.aws.credentials.instance-profile=false
+aws.s3.prefix=test
+
+# JWT
+spring.jwt.secretkey=testsecretkeytestsecretkeytestsecretkey
+
+# Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=test
+spring.mail.password=test


### PR DESCRIPTION
### 이슈 번호
https://github.com/kusitms-com/api.kusitms.com/issues/45

### 💡 작업 내용
- JWT Access/Refresh 토큰 인증 구현 및 토큰 타입 구분 (access/refresh)
- Swagger Bearer 인증 설정 추가
- 회원가입 API (프로필 사진, 수료증 업로드, 이메일 필수)
- 로그인 API (YB/OB 역할 자동 판별, Refresh 토큰 SHA-256 해싱 저장)
- 아이디 중복 체크, 토큰 갱신, 현재 기수 조회 API
- 관리자 회원 승인/반려 API 및 대기 회원 목록 조회 (`@PreAuthorize` 적용)
- 승인/반려 시 HTML 이메일 자동 발송 (큐시즘 배너 포함)
- CORS 설정 보완 (POST, PUT, DELETE, OPTIONS 허용)

### 🎸 기타
- 33기 이하 회원은 수료증 업로드 필수
- 관리자 권한은 DB에서 member_role을 ADMIN으로 직접 설정