### PR TITLE
feat: 마이페이지 계정 관리 API 구현(#52)

### DIFF
--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/Mentor.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/Mentor.java
@@ -65,4 +65,8 @@ public class Mentor {
         this.active = active;
         this.createdAt = LocalDateTime.now();
     }
+
+    public void deactivate() {
+        this.active = false;
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentorRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentorRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
@@ -20,4 +21,6 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
     @EntityGraph(attributePaths = "member")
     Page<Mentor> findByActiveTrueAndCategoryOrderByCreatedAtDesc(MentoringCategory category, Pageable pageable);
+
+    Optional<Mentor> findByMemberUserId(Long userId);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
@@ -26,4 +26,12 @@ public interface MentoringApplicationRepository extends JpaRepository<MentoringA
             @Param("mentorId") Long mentorId,
             @Param("userId") Long userId,
             @Param("statuses") List<ApplicationStatus> statuses);
+
+    @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END " +
+            "FROM MentoringApplication a " +
+            "WHERE a.status = :status " +
+            "AND (a.applicant.userId = :userId OR a.slot.mentor.member.userId = :userId)")
+    boolean existsByUserIdAndStatus(
+            @Param("userId") Long userId,
+            @Param("status") ApplicationStatus status);
 }

--- a/src/main/java/com/kusitms/website/domain/user/Member.java
+++ b/src/main/java/com/kusitms/website/domain/user/Member.java
@@ -1,11 +1,12 @@
 package com.kusitms.website.domain.user;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -87,6 +88,21 @@ public class Member {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void withdraw() {
+        String suffix = DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(LocalDateTime.now());
+        this.id = "withdrawn_" + this.userId + "_" + suffix;
+        this.password = null;
+        this.name = "탈퇴한 회원";
+        this.phone = null;
+        this.part = null;
+        this.profileImageUrl = null;
+        this.certificateImageUrl = null;
+        this.email = null;
+        this.role = null;
+        this.refreshToken = null;
+        this.status = MemberStatus.WITHDRAWN;
     }
 
     public void approve() {

--- a/src/main/java/com/kusitms/website/domain/user/Member.java
+++ b/src/main/java/com/kusitms/website/domain/user/Member.java
@@ -77,6 +77,14 @@ public class Member {
         this.role = role;
     }
 
+    public void updateAccountProfile(String name, String phone, String profileImageUrl) {
+        this.name = name;
+        this.phone = phone;
+        if (profileImageUrl != null) {
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+
     public void approve() {
         this.status = MemberStatus.APPROVED;
     }

--- a/src/main/java/com/kusitms/website/domain/user/Member.java
+++ b/src/main/java/com/kusitms/website/domain/user/Member.java
@@ -85,6 +85,10 @@ public class Member {
         }
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     public void approve() {
         this.status = MemberStatus.APPROVED;
     }

--- a/src/main/java/com/kusitms/website/domain/user/MemberController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberController.java
@@ -4,12 +4,15 @@ import com.kusitms.website.domain.user.dto.request.SignInRequest;
 import com.kusitms.website.domain.user.dto.request.SignUpRequest;
 import com.kusitms.website.domain.user.dto.response.CurrentCardinalResponse;
 import com.kusitms.website.domain.user.dto.response.SignInResponse;
+import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -58,10 +61,28 @@ public class MemberController {
         return ResponseEntity.ok(new BaseResponse<>(response));
     }
 
+    @Operation(summary = "로그아웃")
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse> logout() {
+        Long userId = getAuthenticatedUserId();
+        memberService.logout(userId);
+        return ResponseEntity.ok(new BaseResponse());
+    }
+
     @Operation(summary = "현재 기수 조회")
     @GetMapping("/current-cardinal")
     public ResponseEntity<BaseResponse<CurrentCardinalResponse>> getCurrentCardinal() {
         CurrentCardinalResponse response = memberService.getCurrentCardinal();
         return ResponseEntity.ok(new BaseResponse<>(response));
+    }
+
+    private Long getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getPk();
     }
 }

--- a/src/main/java/com/kusitms/website/domain/user/MemberService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberService.java
@@ -146,6 +146,13 @@ public class MemberService {
         return new CurrentCardinalResponse(cardinal);
     }
 
+    @Transactional
+    public void logout(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        member.clearRefreshToken();
+    }
+
     public List<Member> getPendingMembers() {
         return memberRepository.findAllByStatus(MemberStatus.PENDING);
     }

--- a/src/main/java/com/kusitms/website/domain/user/MemberService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberService.java
@@ -86,6 +86,9 @@ public class MemberService {
         if (member.getStatus() == MemberStatus.PENDING) {
             throw new IllegalArgumentException("관리자 승인 대기 중인 계정입니다. 승인 후 로그인해 주세요.");
         }
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new IllegalArgumentException("이미 탈퇴한 계정입니다.");
+        }
 
         if (!bCryptPasswordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");

--- a/src/main/java/com/kusitms/website/domain/user/MemberStatus.java
+++ b/src/main/java/com/kusitms/website/domain/user/MemberStatus.java
@@ -2,5 +2,6 @@ package com.kusitms.website.domain.user;
 
 public enum MemberStatus {
     PENDING,
-    APPROVED
+    APPROVED,
+    WITHDRAWN
 }

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,19 +1,25 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
+import javax.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/mypage")
@@ -32,6 +38,21 @@ public class MypageController {
     public ResponseEntity<BaseResponse<AccountProfileResponse>> getAccountProfile() {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(mypageService.getAccountProfile(userId)));
+    }
+
+    @PutMapping(value = "/account", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "내 계정 정보 수정", description = "로그인한 사용자의 계정 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<AccountProfileResponse>> updateAccountProfile(
+            @RequestPart("accountProfileUpdateRequest") @Valid AccountProfileUpdateRequest request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.updateAccountProfile(userId, request, profileImage)));
     }
 
     private Long getAuthenticatedUserId() {

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -68,6 +69,19 @@ public class MypageController {
             @RequestBody @Valid PasswordChangeRequest request) {
         Long userId = getAuthenticatedUserId();
         mypageService.changePassword(userId, request);
+        return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @DeleteMapping("/account")
+    @Operation(summary = "회원탈퇴", description = "로그인한 사용자의 계정을 탈퇴 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
+            @ApiResponse(responseCode = "400", description = "탈퇴 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse> withdrawAccount() {
+        Long userId = getAuthenticatedUserId();
+        mypageService.withdrawAccount(userId);
         return ResponseEntity.ok(new BaseResponse());
     }
 

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,0 +1,46 @@
+package com.kusitms.website.domain.user;
+
+import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
+import com.kusitms.website.global.auth.UserPrincipal;
+import com.kusitms.website.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+@Tag(name = "Mypage", description = "마이페이지 API")
+public class MypageController {
+
+    private final MypageService mypageService;
+
+    @GetMapping("/account")
+    @Operation(summary = "내 계정 정보 조회", description = "로그인한 사용자의 계정 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<AccountProfileResponse>> getAccountProfile() {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(mypageService.getAccountProfile(userId)));
+    }
+
+    private Long getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getPk();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,6 +1,7 @@
 package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
@@ -17,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,6 +55,20 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(
                 mypageService.updateAccountProfile(userId, request, profileImage)));
+    }
+
+    @PutMapping("/account/password")
+    @Operation(summary = "비밀번호 변경", description = "로그인한 사용자의 비밀번호를 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 값 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse> changePassword(
+            @RequestBody @Valid PasswordChangeRequest request) {
+        Long userId = getAuthenticatedUserId();
+        mypageService.changePassword(userId, request);
+        return ResponseEntity.ok(new BaseResponse());
     }
 
     private Long getAuthenticatedUserId() {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,5 +1,8 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import com.kusitms.website.domain.mentoring.repository.MentorRepository;
+import com.kusitms.website.domain.mentoring.repository.MentoringApplicationRepository;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
@@ -26,6 +29,8 @@ public class MypageService {
     private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
 
     private final MemberRepository memberRepository;
+    private final MentoringApplicationRepository mentoringApplicationRepository;
+    private final MentorRepository mentorRepository;
     private final S3Service s3Service;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -76,6 +81,23 @@ public class MypageService {
         }
 
         member.updatePassword(bCryptPasswordEncoder.encode(request.getNewPassword()));
+    }
+
+    @Transactional
+    public void withdrawAccount(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        boolean hasActiveMentoring = mentoringApplicationRepository
+                .existsByUserIdAndStatus(userId, ApplicationStatus.ACTIVE);
+        if (hasActiveMentoring) {
+            throw new IllegalArgumentException("진행 중인 멘토링이 있어 탈퇴할 수 없습니다. 멘토링 완료 후 다시 시도해 주세요.");
+        }
+
+        mentorRepository.findByMemberUserId(userId)
+                .ifPresent(mentor -> mentor.deactivate());
+
+        member.withdraw();
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -35,9 +35,7 @@ public class MypageService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public AccountProfileResponse getAccountProfile(Long userId) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-
+        Member member = getActiveMember(userId);
         return AccountProfileResponse.from(member);
     }
 
@@ -47,8 +45,7 @@ public class MypageService {
             AccountProfileUpdateRequest request,
             MultipartFile profileImage
     ) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Member member = getActiveMember(userId);
 
         String normalizedPhone = normalizePhone(request.getPhone());
         if (!PHONE_PATTERN.matcher(normalizedPhone).matches()) {
@@ -67,8 +64,7 @@ public class MypageService {
 
     @Transactional
     public void changePassword(Long userId, PasswordChangeRequest request) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Member member = getActiveMember(userId);
 
         if (!bCryptPasswordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
             throw new IllegalArgumentException("현재 비밀번호가 올바르지 않습니다.");
@@ -85,8 +81,7 @@ public class MypageService {
 
     @Transactional
     public void withdrawAccount(Long userId) {
-        Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        Member member = getActiveMember(userId);
 
         boolean hasActiveMentoring = mentoringApplicationRepository
                 .existsByUserIdAndStatus(userId, ApplicationStatus.ACTIVE);
@@ -98,6 +93,15 @@ public class MypageService {
                 .ifPresent(mentor -> mentor.deactivate());
 
         member.withdraw();
+    }
+
+    private Member getActiveMember(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        if (member.getStatus() == MemberStatus.WITHDRAWN) {
+            throw new IllegalArgumentException("이미 탈퇴한 계정입니다.");
+        }
+        return member;
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,21 +1,76 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.file.S3Service;
+import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MypageService {
 
+    private static final Pattern PHONE_PATTERN =
+            Pattern.compile("^010\\d{8}$");
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png");
+
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
     public AccountProfileResponse getAccountProfile(Long userId) {
         Member member = memberRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         return AccountProfileResponse.from(member);
+    }
+
+    @Transactional
+    public AccountProfileResponse updateAccountProfile(
+            Long userId,
+            AccountProfileUpdateRequest request,
+            MultipartFile profileImage
+    ) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        String normalizedPhone = normalizePhone(request.getPhone());
+        if (!PHONE_PATTERN.matcher(normalizedPhone).matches()) {
+            throw new IllegalArgumentException("올바른 전화번호를 입력해 주세요.");
+        }
+
+        String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            validateImageFile(profileImage);
+            profileImageUrl = s3Service.uploadFile(profileImage, "profile");
+        }
+
+        member.updateAccountProfile(request.getName(), normalizedPhone, profileImageUrl);
+        return AccountProfileResponse.from(member);
+    }
+
+    private void validateImageFile(MultipartFile file) {
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new IllegalArgumentException("10MB 이하의 이미지만 업로드 가능합니다.");
+        }
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new IllegalArgumentException("이미지 파일(jpg, png)만 업로드 가능합니다.");
+        }
+
+        String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException("이미지 파일(jpg, png)만 업로드 가능합니다.");
+        }
+    }
+
+    private String normalizePhone(String phone) {
+        return phone.replaceAll("[^0-9]", "");
     }
 }

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,0 +1,21 @@
+package com.kusitms.website.domain.user;
+
+import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MypageService {
+
+    private final MemberRepository memberRepository;
+
+    public AccountProfileResponse getAccountProfile(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return AccountProfileResponse.from(member);
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -2,8 +2,10 @@ package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +18,8 @@ import java.util.regex.Pattern;
 @Transactional(readOnly = true)
 public class MypageService {
 
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,}$");
     private static final Pattern PHONE_PATTERN =
             Pattern.compile("^010\\d{8}$");
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
@@ -23,6 +27,7 @@ public class MypageService {
 
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public AccountProfileResponse getAccountProfile(Long userId) {
         Member member = memberRepository.findById(userId)
@@ -53,6 +58,24 @@ public class MypageService {
 
         member.updateAccountProfile(request.getName(), normalizedPhone, profileImageUrl);
         return AccountProfileResponse.from(member);
+    }
+
+    @Transactional
+    public void changePassword(Long userId, PasswordChangeRequest request) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!bCryptPasswordEncoder.matches(request.getCurrentPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 올바르지 않습니다.");
+        }
+        if (!PASSWORD_PATTERN.matcher(request.getNewPassword()).matches()) {
+            throw new IllegalArgumentException("영문, 숫자, 특수문자를 포함해 8자 이상이어야 합니다.");
+        }
+        if (!request.getNewPassword().equals(request.getNewPasswordConfirm())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        member.updatePassword(bCryptPasswordEncoder.encode(request.getNewPassword()));
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/AccountProfileUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/AccountProfileUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "계정 정보 수정 요청")
+public class AccountProfileUpdateRequest {
+
+    @NotBlank
+    @Schema(description = "이름", required = true)
+    private String name;
+
+    @NotBlank
+    @Schema(description = "전화번호", required = true)
+    private String phone;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,25 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "비밀번호 변경 요청")
+public class PasswordChangeRequest {
+
+    @NotBlank
+    @Schema(description = "현재 비밀번호", required = true)
+    private String currentPassword;
+
+    @NotBlank
+    @Schema(description = "새 비밀번호", required = true)
+    private String newPassword;
+
+    @NotBlank
+    @Schema(description = "새 비밀번호 확인", required = true)
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/AccountProfileResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/AccountProfileResponse.java
@@ -1,0 +1,42 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.Part;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "내 계정 정보 조회 응답")
+public class AccountProfileResponse {
+
+    @Schema(description = "계정 프로필 이미지 URL")
+    private String profileImageUrl;
+
+    @Schema(description = "이름")
+    private String name;
+
+    @Schema(description = "전화번호")
+    private String phone;
+
+    @Schema(description = "기수")
+    private Integer cardinal;
+
+    @Schema(description = "아이디")
+    private String id;
+
+    @Schema(description = "파트")
+    private Part part;
+
+    public static AccountProfileResponse from(Member member) {
+        return AccountProfileResponse.builder()
+                .profileImageUrl(member.getProfileImageUrl())
+                .name(member.getName())
+                .phone(member.getPhone())
+                .cardinal(member.getCardinal())
+                .id(member.getId())
+                .part(member.getPart())
+                .build();
+    }
+}


### PR DESCRIPTION
### 관련 이슈
- Closed #52 

### 작업 내용
- 마이페이지 계정 조회 API 구현
- 마이페이지 계정 정보 수정 API 구현
- 마이페이지 비밀번호 변경 API 구현
- 로그아웃 API 구현
- 마이페이지 회원탈퇴 API 구현

### 상세 변경 사항
- `MypageController`, `MypageService`를 새로 추가하여 마이페이지 계정 관리 책임 분리
- `GET /api/mypage/account` 추가
- `PUT /api/mypage/account` 추가
- `PUT /api/mypage/account/password` 추가
- `POST /api/auth/logout` 추가
- `DELETE /api/mypage/account` 추가

### 구현 포인트
- 인증 관련 API는 기존 `MemberController`에 유지하고, 마이페이지 계정 관리 기능은 `MypageController`로 분리했습니다.
- 계정 수정은 `multipart/form-data` 기반으로 구현하여 프로필 이미지와 텍스트 정보를 함께 수정할 수 있도록 했습니다.
- 비밀번호 변경은 현재 비밀번호 검증, 새 비밀번호 규칙 검증, 새 비밀번호 확인 일치 검증 후 암호화 저장하도록 구현했습니다.
- 로그아웃은 현재 JWT 구조에 맞춰 refresh token 무효화 방식으로 처리했습니다.
- 회원탈퇴는 연관 엔티티 관계를 고려해 실제 삭제 대신 `WITHDRAWN` 상태 전환과 개인정보 익명화 방식으로 처리했습니다.
- OB 회원 탈퇴 시 멘토 프로필이 노출되지 않도록 멘토 활성 상태도 함께 비활성화했습니다.

### 테스트
- `./gradlew compileJava` 성공 확인

### 참고 사항
- 카카오 계정 연동 기능은 이번 PR 범위에서 제외했습니다.
- 회원탈퇴는 `ACTIVE` 상태 멘토링이 존재할 경우 차단되도록 구현했습니다.