### PR TITLE
feat: 마이페이지 및 OB 멘토링 관리 API 구현(#53)

### DIFF
--- a/src/main/java/com/kusitms/website/domain/mentoring/dto/response/MentoringReviewDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/dto/response/MentoringReviewDetailResponse.java
@@ -1,6 +1,7 @@
 package com.kusitms.website.domain.mentoring.dto.response;
 
 import com.kusitms.website.domain.mentoring.entity.MentoringReview;
+import com.kusitms.website.domain.mentoring.entity.RecommendationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,9 @@ public class MentoringReviewDetailResponse {
     @Schema(description = "선택된 키워드 목록")
     private List<String> keywords;
 
+    @Schema(description = "추천 여부")
+    private RecommendationType recommendationType;
+
     @Schema(description = "작성일")
     private LocalDateTime createdAt;
 
@@ -42,6 +46,7 @@ public class MentoringReviewDetailResponse {
                 .reviewerCardinal(review.getReviewer().getCardinal())
                 .content(review.getContent())
                 .keywords(keywordNames)
+                .recommendationType(review.getRecommendationType())
                 .createdAt(review.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/ApplicationStatus.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/ApplicationStatus.java
@@ -3,6 +3,7 @@ package com.kusitms.website.domain.mentoring.entity;
 public enum ApplicationStatus {
     PENDING,
     ACTIVE,
+    COMPLETED,
     REJECTED,
     CANCELED
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/Mentor.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/Mentor.java
@@ -39,11 +39,15 @@ public class Mentor {
     @Column(nullable = false)
     private MentoringMethod method;
 
+    private Integer durationMinutes;
+
     @Column(nullable = false)
     private Integer pricePerHour;
 
     @Column(columnDefinition = "TEXT")
     private String introduction;
+
+    private boolean acceptingRequests;
 
     private boolean active;
 
@@ -52,18 +56,54 @@ public class Mentor {
     @Builder
     public Mentor(Member member, String title, String profileImageUrl,
                   MentoringCategory category, String experience,
-                  MentoringMethod method, Integer pricePerHour,
-                  String introduction, boolean active) {
+                  MentoringMethod method, Integer durationMinutes, Integer pricePerHour,
+                  String introduction, boolean acceptingRequests, boolean active) {
         this.member = member;
         this.title = title;
         this.profileImageUrl = profileImageUrl;
         this.category = category;
         this.experience = experience;
         this.method = method;
+        this.durationMinutes = durationMinutes;
         this.pricePerHour = pricePerHour;
         this.introduction = introduction;
+        this.acceptingRequests = acceptingRequests;
         this.active = active;
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateProfile(String title, String profileImageUrl, MentoringCategory category,
+                              String experience, MentoringMethod method, Integer durationMinutes,
+                              Integer pricePerHour, String introduction) {
+        this.title = title;
+        if (profileImageUrl != null) {
+            this.profileImageUrl = profileImageUrl;
+        }
+        this.category = category;
+        this.experience = experience;
+        this.method = method;
+        this.durationMinutes = durationMinutes;
+        this.pricePerHour = pricePerHour;
+        this.introduction = introduction;
+    }
+
+    public void updateAcceptingRequests(boolean acceptingRequests) {
+        this.acceptingRequests = acceptingRequests;
+    }
+
+    public void updateVisibility(boolean visible) {
+        this.active = visible;
+    }
+
+    public boolean isProfileCompleted() {
+        return profileImageUrl != null && !profileImageUrl.isBlank()
+                && title != null && !title.isBlank()
+                && experience != null && !experience.isBlank()
+                && introduction != null && !introduction.isBlank()
+                && category != null
+                && method != null
+                && durationMinutes != null
+                && pricePerHour != null;
     }
 
     public void deactivate() {

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringApplication.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringApplication.java
@@ -30,6 +30,9 @@ public class MentoringApplication {
     @Column(length = 500)
     private String message;
 
+    @Column(length = 300)
+    private String rejectionReason;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ApplicationStatus status;
@@ -48,5 +51,18 @@ public class MentoringApplication {
 
     public void updateStatus(ApplicationStatus status) {
         this.status = status;
+    }
+
+    public void approve() {
+        this.status = ApplicationStatus.ACTIVE;
+    }
+
+    public void complete() {
+        this.status = ApplicationStatus.COMPLETED;
+    }
+
+    public void reject(String rejectionReason) {
+        this.status = ApplicationStatus.REJECTED;
+        this.rejectionReason = rejectionReason;
     }
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringReview.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringReview.java
@@ -29,8 +29,16 @@ public class MentoringReview {
     @JoinColumn(name = "user_id", nullable = false)
     private Member reviewer;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id", nullable = false, unique = true)
+    private MentoringApplication application;
+
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RecommendationType recommendationType;
 
     private LocalDateTime createdAt;
 
@@ -38,10 +46,13 @@ public class MentoringReview {
     private List<MentoringReviewKeyword> keywords = new ArrayList<>();
 
     @Builder
-    public MentoringReview(Mentor mentor, Member reviewer, String content) {
+    public MentoringReview(Mentor mentor, Member reviewer, MentoringApplication application,
+                           String content, RecommendationType recommendationType) {
         this.mentor = mentor;
         this.reviewer = reviewer;
+        this.application = application;
         this.content = content;
+        this.recommendationType = recommendationType;
         this.createdAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringSlot.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/MentoringSlot.java
@@ -48,4 +48,10 @@ public class MentoringSlot {
         this.slotType = slotType;
         this.maxAttendees = maxAttendees;
     }
+
+    public void updateSchedule(LocalTime endTime, SlotType slotType, int maxAttendees) {
+        this.endTime = endTime;
+        this.slotType = slotType;
+        this.maxAttendees = maxAttendees;
+    }
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/entity/RecommendationType.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/entity/RecommendationType.java
@@ -1,0 +1,7 @@
+package com.kusitms.website.domain.mentoring.entity;
+
+public enum RecommendationType {
+    RECOMMEND,
+    NEUTRAL,
+    NOT_RECOMMEND
+}

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
@@ -2,6 +2,8 @@ package com.kusitms.website.domain.mentoring.repository;
 
 import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
 import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
@@ -55,4 +57,10 @@ public interface MentoringApplicationRepository extends JpaRepository<MentoringA
     @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member", "applicant"})
     List<MentoringApplication> findBySlotMentorMemberUserIdAndStatusInOrderByCreatedAtDesc(
             Long userId, List<ApplicationStatus> statuses);
+
+    @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member", "applicant"})
+    Page<MentoringApplication> findBySlotMentorMemberUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member", "applicant"})
+    Optional<MentoringApplication> findByApplicationIdAndSlotMentorMemberUserId(Long applicationId, Long userId);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
@@ -16,6 +16,14 @@ public interface MentoringApplicationRepository extends JpaRepository<MentoringA
     int countBySlotIdAndStatusIn(@Param("slotId") Long slotId,
                                  @Param("statuses") List<ApplicationStatus> statuses);
 
+    @Query("SELECT a.slot.slotId, COUNT(a) " +
+            "FROM MentoringApplication a " +
+            "WHERE a.slot.slotId IN :slotIds AND a.status IN :statuses " +
+            "GROUP BY a.slot.slotId")
+    List<Object[]> countBySlotIdsAndStatusIn(
+            @Param("slotIds") List<Long> slotIds,
+            @Param("statuses") List<ApplicationStatus> statuses);
+
     boolean existsBySlotSlotIdAndApplicantUserIdAndStatusIn(
             Long slotId, Long userId, List<ApplicationStatus> statuses);
 

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
@@ -3,6 +3,7 @@ package com.kusitms.website.domain.mentoring.repository;
 import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
 import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,11 +37,14 @@ public interface MentoringApplicationRepository extends JpaRepository<MentoringA
             @Param("userId") Long userId,
             @Param("status") ApplicationStatus status);
 
+    @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member", "applicant"})
     Optional<MentoringApplication> findByApplicationIdAndApplicantUserId(Long applicationId, Long userId);
 
+    @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member"})
     List<MentoringApplication> findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(
             Long userId, List<ApplicationStatus> statuses);
 
+    @EntityGraph(attributePaths = {"slot", "slot.mentor", "slot.mentor.member", "applicant"})
     List<MentoringApplication> findBySlotMentorMemberUserIdAndStatusInOrderByCreatedAtDesc(
             Long userId, List<ApplicationStatus> statuses);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringApplicationRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MentoringApplicationRepository extends JpaRepository<MentoringApplication, Long> {
 
@@ -34,4 +35,12 @@ public interface MentoringApplicationRepository extends JpaRepository<MentoringA
     boolean existsByUserIdAndStatus(
             @Param("userId") Long userId,
             @Param("status") ApplicationStatus status);
+
+    Optional<MentoringApplication> findByApplicationIdAndApplicantUserId(Long applicationId, Long userId);
+
+    List<MentoringApplication> findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(
+            Long userId, List<ApplicationStatus> statuses);
+
+    List<MentoringApplication> findBySlotMentorMemberUserIdAndStatusInOrderByCreatedAtDesc(
+            Long userId, List<ApplicationStatus> statuses);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringKeywordRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringKeywordRepository.java
@@ -3,5 +3,9 @@ package com.kusitms.website.domain.mentoring.repository;
 import com.kusitms.website.domain.mentoring.entity.MentoringKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MentoringKeywordRepository extends JpaRepository<MentoringKeyword, Long> {
+
+    List<MentoringKeyword> findByKeywordIdIn(List<Long> keywordIds);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MentoringReviewRepository extends JpaRepository<MentoringReview, Long> {
 
     Page<MentoringReview> findByMentorMentorIdOrderByCreatedAtDesc(Long mentorId, Pageable pageable);
+
+    boolean existsByApplicationApplicationId(Long applicationId);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
@@ -6,10 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
 
+import java.util.List;
+
 public interface MentoringReviewRepository extends JpaRepository<MentoringReview, Long> {
 
     @EntityGraph(attributePaths = {"reviewer", "keywords", "keywords.keyword"})
     Page<MentoringReview> findByMentorMentorIdOrderByCreatedAtDesc(Long mentorId, Pageable pageable);
 
     boolean existsByApplicationApplicationId(Long applicationId);
+
+    List<MentoringReview> findByApplicationApplicationIdIn(List<Long> applicationIds);
 }

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringReviewRepository.java
@@ -4,9 +4,11 @@ import com.kusitms.website.domain.mentoring.entity.MentoringReview;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 public interface MentoringReviewRepository extends JpaRepository<MentoringReview, Long> {
 
+    @EntityGraph(attributePaths = {"reviewer", "keywords", "keywords.keyword"})
     Page<MentoringReview> findByMentorMentorIdOrderByCreatedAtDesc(Long mentorId, Pageable pageable);
 
     boolean existsByApplicationApplicationId(Long applicationId);

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringSlotRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringSlotRepository.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 
 public interface MentoringSlotRepository extends JpaRepository<MentoringSlot, Long> {
 
+    boolean existsByMentorMentorIdAndDateGreaterThanEqual(Long mentorId, LocalDate fromDate);
+
     List<MentoringSlot> findByMentorMentorIdAndDateGreaterThanEqualOrderByDateAscStartTimeAsc(
             Long mentorId, LocalDate fromDate);
 

--- a/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringSlotRepository.java
+++ b/src/main/java/com/kusitms/website/domain/mentoring/repository/MentoringSlotRepository.java
@@ -15,10 +15,18 @@ public interface MentoringSlotRepository extends JpaRepository<MentoringSlot, Lo
 
     boolean existsByMentorMentorIdAndDateGreaterThanEqual(Long mentorId, LocalDate fromDate);
 
+    List<MentoringSlot> findByMentorMentorIdAndDateOrderByStartTimeAsc(Long mentorId, LocalDate date);
+
     List<MentoringSlot> findByMentorMentorIdAndDateGreaterThanEqualOrderByDateAscStartTimeAsc(
             Long mentorId, LocalDate fromDate);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM MentoringSlot s WHERE s.slotId = :slotId")
     Optional<MentoringSlot> findByIdWithLock(@Param("slotId") Long slotId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM MentoringSlot s WHERE s.mentor.mentorId = :mentorId AND s.date = :date ORDER BY s.startTime ASC")
+    List<MentoringSlot> findByMentorMentorIdAndDateWithLock(
+            @Param("mentorId") Long mentorId,
+            @Param("date") LocalDate date);
 }

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -2,9 +2,12 @@ package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
+import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
@@ -114,6 +117,47 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         mypageService.createMentoringReview(userId, request);
         return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @GetMapping("/ob/profile")
+    @Operation(summary = "OB 프로필 조회", description = "로그인한 OB 사용자의 멘토 프로필 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBProfileResponse>> getOBProfile() {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(mypageService.getOBProfile(userId)));
+    }
+
+    @PutMapping(value = "/ob/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "OB 프로필 저장", description = "로그인한 OB 사용자의 멘토 프로필 정보를 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "저장 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBProfileResponse>> updateOBProfile(
+            @RequestPart("obProfileUpdateRequest") @Valid OBProfileUpdateRequest request,
+            @RequestPart(value = "mentorProfileImage", required = false) MultipartFile mentorProfileImage) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.updateOBProfile(userId, request, mentorProfileImage)));
+    }
+
+    @PutMapping("/ob/profile/visibility")
+    @Operation(summary = "OB 프로필 공개 토글", description = "멘토링 신청 받기 토글 상태를 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "변경 성공"),
+            @ApiResponse(responseCode = "400", description = "변경 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBProfileResponse>> updateOBProfileVisibility(
+            @RequestBody @Valid OBProfileVisibilityUpdateRequest request) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.updateOBProfileVisibility(userId, request)));
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,6 +1,7 @@
 package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
@@ -20,6 +21,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -98,6 +100,20 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(
                 mypageService.getApplicationRejectionReason(userId, applicationId)));
+    }
+
+    @PostMapping("/reviews")
+    @Operation(summary = "멘토링 후기 작성", description = "완료된 멘토링에 대한 후기를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "작성 성공"),
+            @ApiResponse(responseCode = "400", description = "작성 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse> createMentoringReview(
+            @RequestBody @Valid MentoringReviewCreateRequest request) {
+        Long userId = getAuthenticatedUserId();
+        mypageService.createMentoringReview(userId, request);
+        return ResponseEntity.ok(new BaseResponse());
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,6 +1,7 @@
 package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.ApplicationRejectRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
@@ -8,6 +9,7 @@ import com.kusitms.website.domain.user.dto.request.OBScheduleUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.OBMentoringRequestsResponse;
 import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
 import com.kusitms.website.domain.user.dto.response.OBScheduleResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -186,6 +189,35 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(
                 mypageService.updateOBSchedule(userId, request)));
+    }
+
+    @GetMapping("/ob/requests")
+    @Operation(summary = "OB 멘토링 요청 목록 조회", description = "로그인한 OB 사용자의 멘토링 요청 목록을 상태별로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBMentoringRequestsResponse>> getOBMentoringRequests(
+            @RequestParam(defaultValue = "0") int page) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.getOBMentoringRequests(userId, page)));
+    }
+
+    @PostMapping("/ob/requests/{applicationId}/reject")
+    @Operation(summary = "OB 멘토링 요청 거절", description = "대기 중인 멘토링 요청을 거절하고 사유를 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "거절 성공"),
+            @ApiResponse(responseCode = "400", description = "거절 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse> rejectOBMentoringRequest(
+            @PathVariable Long applicationId,
+            @RequestBody @Valid ApplicationRejectRequest request) {
+        Long userId = getAuthenticatedUserId();
+        mypageService.rejectOBMentoringRequest(userId, applicationId, request);
+        return ResponseEntity.ok(new BaseResponse());
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -4,10 +4,12 @@ import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.OBScheduleUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
 import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
+import com.kusitms.website.domain.user.dto.response.OBScheduleResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
@@ -158,6 +160,32 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(
                 mypageService.updateOBProfileVisibility(userId, request)));
+    }
+
+    @GetMapping("/ob/schedule")
+    @Operation(summary = "OB 가능 시간 조회", description = "로그인한 OB 사용자의 가능 시간 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBScheduleResponse>> getOBSchedule() {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(mypageService.getOBSchedule(userId)));
+    }
+
+    @PutMapping("/ob/schedule")
+    @Operation(summary = "OB 가능 시간 저장", description = "로그인한 OB 사용자의 날짜별 가능 시간을 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장 성공"),
+            @ApiResponse(responseCode = "400", description = "저장 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<OBScheduleResponse>> updateOBSchedule(
+            @RequestBody @Valid OBScheduleUpdateRequest request) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.updateOBSchedule(userId, request)));
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -3,6 +3,8 @@ package com.kusitms.website.domain.user;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
+import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
 import javax.validation.Valid;
@@ -17,6 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +34,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class MypageController {
 
     private final MypageService mypageService;
+
+    @GetMapping
+    @Operation(summary = "YB 마이페이지 조회", description = "로그인한 YB 사용자의 마이페이지 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<YBMypageResponse>> getYBMypage() {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(mypageService.getYBMypage(userId)));
+    }
 
     @GetMapping("/account")
     @Operation(summary = "내 계정 정보 조회", description = "로그인한 사용자의 계정 정보를 조회합니다.")
@@ -70,6 +84,20 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         mypageService.changePassword(userId, request);
         return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @GetMapping("/applications/{applicationId}/rejection-reason")
+    @Operation(summary = "거절 사유 조회", description = "로그인한 사용자의 거절된 멘토링 신청 사유를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<ApplicationRejectionReasonResponse>> getApplicationRejectionReason(
+            @PathVariable Long applicationId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.getApplicationRejectionReason(userId, applicationId)));
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageController.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageController.java
@@ -1,5 +1,6 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.mentoring.dto.response.MentoringReviewListResponse;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.ApplicationRejectRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
@@ -218,6 +219,33 @@ public class MypageController {
         Long userId = getAuthenticatedUserId();
         mypageService.rejectOBMentoringRequest(userId, applicationId, request);
         return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @PostMapping("/ob/requests/{applicationId}/approve")
+    @Operation(summary = "OB 멘토링 요청 승인", description = "대기 중인 멘토링 요청을 승인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "승인 성공"),
+            @ApiResponse(responseCode = "400", description = "승인 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse> approveOBMentoringRequest(@PathVariable Long applicationId) {
+        Long userId = getAuthenticatedUserId();
+        mypageService.approveOBMentoringRequest(userId, applicationId);
+        return ResponseEntity.ok(new BaseResponse());
+    }
+
+    @GetMapping("/ob/reviews")
+    @Operation(summary = "OB 받은 후기 조회", description = "로그인한 OB 사용자의 받은 후기 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<MentoringReviewListResponse>> getOBReceivedReviews(
+            @RequestParam(defaultValue = "0") int page) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(
+                mypageService.getOBReceivedReviews(userId, page)));
     }
 
     @DeleteMapping("/account")

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -98,13 +98,24 @@ public class MypageService {
                 .map(application -> MyMentoringCardResponse.from(application, false))
                 .collect(Collectors.toList());
 
-        List<MyMentoringCardResponse> completedMentorings = mentoringApplicationRepository
-                .findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(userId, FINISHED_STATUSES)
+        List<MentoringApplication> finishedApplications = mentoringApplicationRepository
+                .findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(userId, FINISHED_STATUSES);
+
+        List<Long> completedApplicationIds = finishedApplications.stream()
+                .filter(application -> application.getStatus() == ApplicationStatus.COMPLETED)
+                .map(MentoringApplication::getApplicationId)
+                .collect(Collectors.toList());
+
+        Set<Long> reviewedApplicationIds = mentoringReviewRepository.findByApplicationApplicationIdIn(completedApplicationIds)
                 .stream()
+                .map(review -> review.getApplication().getApplicationId())
+                .collect(Collectors.toSet());
+
+        List<MyMentoringCardResponse> completedMentorings = finishedApplications.stream()
                 .map(application -> MyMentoringCardResponse.from(
                         application,
                         application.getStatus() == ApplicationStatus.COMPLETED
-                                && !mentoringReviewRepository.existsByApplicationApplicationId(application.getApplicationId())
+                                && !reviewedApplicationIds.contains(application.getApplicationId())
                 ))
                 .collect(Collectors.toList());
 
@@ -315,7 +326,9 @@ public class MypageService {
         SlotType slotType = request.getGroupMentoring() ? SlotType.ONE_TO_N : SlotType.ONE_TO_ONE;
         int maxAttendees = request.getGroupMentoring() ? request.getMaxAttendees() : 1;
 
-        List<LocalTime> sortedStartTimes = request.getStartTimes().stream()
+        List<LocalTime> requestStartTimes = request.getStartTimes() == null ? Collections.emptyList() : request.getStartTimes();
+
+        List<LocalTime> sortedStartTimes = requestStartTimes.stream()
                 .sorted()
                 .collect(Collectors.toList());
 
@@ -394,11 +407,12 @@ public class MypageService {
 
         int currentApplicants = mentoringApplicationRepository.countBySlotIdAndStatusIn(
                 slot.getSlotId(), OCCUPYING_STATUSES);
+        int otherApplicants = currentApplicants - 1;
 
-        if (slot.getSlotType() == SlotType.ONE_TO_ONE && currentApplicants >= 1) {
+        if (slot.getSlotType() == SlotType.ONE_TO_ONE && otherApplicants >= 1) {
             throw new IllegalArgumentException("해당 시간대는 이미 예약되었습니다.");
         }
-        if (slot.getSlotType() == SlotType.ONE_TO_N && currentApplicants >= slot.getMaxAttendees()) {
+        if (slot.getSlotType() == SlotType.ONE_TO_N && otherApplicants >= slot.getMaxAttendees()) {
             throw new IllegalArgumentException("해당 시간대의 최대 인원에 도달했습니다.");
         }
 
@@ -506,12 +520,14 @@ public class MypageService {
             throw new IllegalArgumentException("소그룹 멘토링 최대 인원을 선택해 주세요.");
         }
 
-        long distinctStartTimeCount = request.getStartTimes().stream().distinct().count();
-        if (distinctStartTimeCount != request.getStartTimes().size()) {
+        List<LocalTime> startTimes = request.getStartTimes() == null ? Collections.emptyList() : request.getStartTimes();
+
+        long distinctStartTimeCount = startTimes.stream().distinct().count();
+        if (distinctStartTimeCount != startTimes.size()) {
             throw new IllegalArgumentException("중복된 시간 슬롯은 등록할 수 없습니다.");
         }
 
-        for (LocalTime startTime : request.getStartTimes()) {
+        for (LocalTime startTime : startTimes) {
             validateStartTime(startTime, mentor.getDurationMinutes());
         }
     }

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,20 +1,28 @@
 package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
 import com.kusitms.website.domain.mentoring.repository.MentorRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringApplicationRepository;
+import com.kusitms.website.domain.mentoring.repository.MentoringReviewRepository;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
+import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.MyMentoringCardResponse;
+import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,9 +38,65 @@ public class MypageService {
 
     private final MemberRepository memberRepository;
     private final MentoringApplicationRepository mentoringApplicationRepository;
+    private final MentoringReviewRepository mentoringReviewRepository;
     private final MentorRepository mentorRepository;
     private final S3Service s3Service;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private static final List<ApplicationStatus> PENDING_STATUSES =
+            Collections.singletonList(ApplicationStatus.PENDING);
+    private static final List<ApplicationStatus> ACTIVE_STATUSES =
+            Collections.singletonList(ApplicationStatus.ACTIVE);
+    private static final List<ApplicationStatus> FINISHED_STATUSES =
+            Arrays.asList(ApplicationStatus.COMPLETED, ApplicationStatus.REJECTED);
+
+    public YBMypageResponse getYBMypage(Long userId) {
+        Member member = getActiveMember(userId);
+
+        List<MyMentoringCardResponse> pendingMentorings = mentoringApplicationRepository
+                .findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(userId, PENDING_STATUSES)
+                .stream()
+                .map(application -> MyMentoringCardResponse.from(application, false))
+                .collect(Collectors.toList());
+
+        List<MyMentoringCardResponse> activeMentorings = mentoringApplicationRepository
+                .findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(userId, ACTIVE_STATUSES)
+                .stream()
+                .map(application -> MyMentoringCardResponse.from(application, false))
+                .collect(Collectors.toList());
+
+        List<MyMentoringCardResponse> completedMentorings = mentoringApplicationRepository
+                .findByApplicantUserIdAndStatusInOrderByCreatedAtDesc(userId, FINISHED_STATUSES)
+                .stream()
+                .map(application -> MyMentoringCardResponse.from(
+                        application,
+                        application.getStatus() == ApplicationStatus.COMPLETED
+                                && !mentoringReviewRepository.existsByApplicationApplicationId(application.getApplicationId())
+                ))
+                .collect(Collectors.toList());
+
+        return YBMypageResponse.builder()
+                .profile(AccountProfileResponse.from(member))
+                .pendingMentorings(pendingMentorings)
+                .activeMentorings(activeMentorings)
+                .completedMentorings(completedMentorings)
+                .build();
+    }
+
+    public ApplicationRejectionReasonResponse getApplicationRejectionReason(Long userId, Long applicationId) {
+        MentoringApplication application = mentoringApplicationRepository
+                .findByApplicationIdAndApplicantUserId(applicationId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멘토링 신청입니다."));
+
+        if (application.getStatus() != ApplicationStatus.REJECTED) {
+            throw new IllegalArgumentException("거절된 멘토링 신청만 조회할 수 있습니다.");
+        }
+
+        return new ApplicationRejectionReasonResponse(
+                application.getApplicationId(),
+                application.getRejectionReason()
+        );
+    }
 
     public AccountProfileResponse getAccountProfile(Long userId) {
         Member member = getActiveMember(userId);

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -5,17 +5,22 @@ import com.kusitms.website.domain.mentoring.entity.MentoringKeyword;
 import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
 import com.kusitms.website.domain.mentoring.entity.MentoringReview;
 import com.kusitms.website.domain.mentoring.entity.MentoringReviewKeyword;
+import com.kusitms.website.domain.mentoring.entity.Mentor;
 import com.kusitms.website.domain.mentoring.repository.MentorRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringApplicationRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringKeywordRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringReviewRepository;
+import com.kusitms.website.domain.mentoring.repository.MentoringSlotRepository;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
+import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
 import com.kusitms.website.domain.user.dto.response.MyMentoringCardResponse;
+import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -25,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -46,6 +52,7 @@ public class MypageService {
     private final MentoringKeywordRepository mentoringKeywordRepository;
     private final MentoringReviewRepository mentoringReviewRepository;
     private final MentorRepository mentorRepository;
+    private final MentoringSlotRepository mentoringSlotRepository;
     private final S3Service s3Service;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -148,6 +155,67 @@ public class MypageService {
         return AccountProfileResponse.from(member);
     }
 
+    public OBProfileResponse getOBProfile(Long userId) {
+        Member member = getOBMember(userId);
+        Mentor mentor = mentorRepository.findByMemberUserId(userId).orElse(null);
+        return OBProfileResponse.from(member, mentor);
+    }
+
+    @Transactional
+    public OBProfileResponse updateOBProfile(
+            Long userId,
+            OBProfileUpdateRequest request,
+            MultipartFile mentorProfileImage
+    ) {
+        Member member = getOBMember(userId);
+        Mentor mentor = mentorRepository.findByMemberUserId(userId)
+                .orElseGet(() -> mentorRepository.save(Mentor.builder()
+                        .member(member)
+                        .title(request.getTitle())
+                        .profileImageUrl(null)
+                        .category(request.getCategory())
+                        .experience(request.getExperience())
+                        .method(request.getMethod())
+                        .durationMinutes(request.getDurationMinutes())
+                        .pricePerHour(request.getPricePerHour())
+                        .introduction(request.getIntroduction())
+                        .acceptingRequests(false)
+                        .active(false)
+                        .build()));
+
+        String mentorProfileImageUrl = null;
+        if (mentorProfileImage != null && !mentorProfileImage.isEmpty()) {
+            validateImageFile(mentorProfileImage);
+            mentorProfileImageUrl = s3Service.uploadFile(mentorProfileImage, "mentor-profile");
+        }
+
+        mentor.updateProfile(
+                request.getTitle(),
+                mentorProfileImageUrl,
+                request.getCategory(),
+                request.getExperience(),
+                request.getMethod(),
+                request.getDurationMinutes(),
+                request.getPricePerHour(),
+                request.getIntroduction()
+        );
+        mentor.updateVisibility(calculateMentorVisibility(mentor));
+
+        return OBProfileResponse.from(member, mentor);
+    }
+
+    @Transactional
+    public OBProfileResponse updateOBProfileVisibility(Long userId, OBProfileVisibilityUpdateRequest request) {
+        Member member = getOBMember(userId);
+        Mentor mentor = mentorRepository.findByMemberUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("멘토 프로필을 먼저 작성해 주세요."));
+
+        mentor.updateAcceptingRequests(request.getEnabled());
+        mentor.updateVisibility(calculateMentorVisibility(mentor));
+
+        return OBProfileResponse.from(member, mentor);
+    }
+
     @Transactional
     public AccountProfileResponse updateAccountProfile(
             Long userId,
@@ -211,6 +279,25 @@ public class MypageService {
             throw new IllegalArgumentException("이미 탈퇴한 계정입니다.");
         }
         return member;
+    }
+
+    private Member getOBMember(Long userId) {
+        Member member = getActiveMember(userId);
+        if (member.getRole() != MemberRole.OB) {
+            throw new IllegalArgumentException("OB 회원만 접근할 수 있습니다.");
+        }
+        return member;
+    }
+
+    private boolean calculateMentorVisibility(Mentor mentor) {
+        if (!mentor.isAcceptingRequests()) {
+            return false;
+        }
+        if (!mentor.isProfileCompleted()) {
+            return false;
+        }
+        return mentoringSlotRepository.existsByMentorMentorIdAndDateGreaterThanEqual(
+                mentor.getMentorId(), LocalDate.now());
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -15,6 +15,7 @@ import com.kusitms.website.domain.mentoring.repository.MentoringReviewRepository
 import com.kusitms.website.domain.mentoring.repository.MentoringSlotRepository;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.ApplicationRejectRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
@@ -22,12 +23,16 @@ import com.kusitms.website.domain.user.dto.request.OBScheduleUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.OBMentoringRequestCardResponse;
+import com.kusitms.website.domain.user.dto.response.OBMentoringRequestsResponse;
 import com.kusitms.website.domain.user.dto.response.OBScheduleDateResponse;
 import com.kusitms.website.domain.user.dto.response.OBScheduleResponse;
 import com.kusitms.website.domain.user.dto.response.MyMentoringCardResponse;
 import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +40,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -199,6 +203,43 @@ public class MypageService {
                 .build();
     }
 
+    public OBMentoringRequestsResponse getOBMentoringRequests(Long userId, int page) {
+        getExistingMentor(userId);
+
+        Page<MentoringApplication> requestPage = mentoringApplicationRepository
+                .findBySlotMentorMemberUserIdOrderByCreatedAtDesc(userId, PageRequest.of(page, 10));
+
+        List<OBMentoringRequestCardResponse> pendingRequests = requestPage.getContent().stream()
+                .filter(application -> application.getStatus() == ApplicationStatus.PENDING)
+                .map(OBMentoringRequestCardResponse::from)
+                .collect(Collectors.toList());
+
+        List<OBMentoringRequestCardResponse> activeRequests = requestPage.getContent().stream()
+                .filter(application -> application.getStatus() == ApplicationStatus.ACTIVE)
+                .map(OBMentoringRequestCardResponse::from)
+                .collect(Collectors.toList());
+
+        List<OBMentoringRequestCardResponse> completedRequests = requestPage.getContent().stream()
+                .filter(application -> application.getStatus() == ApplicationStatus.COMPLETED)
+                .map(OBMentoringRequestCardResponse::from)
+                .collect(Collectors.toList());
+
+        List<OBMentoringRequestCardResponse> rejectedRequests = requestPage.getContent().stream()
+                .filter(application -> application.getStatus() == ApplicationStatus.REJECTED)
+                .map(OBMentoringRequestCardResponse::from)
+                .collect(Collectors.toList());
+
+        return OBMentoringRequestsResponse.builder()
+                .totalCount(requestPage.getTotalElements())
+                .totalPages(requestPage.getTotalPages())
+                .currentPage(requestPage.getNumber())
+                .pendingRequests(pendingRequests)
+                .activeRequests(activeRequests)
+                .completedRequests(completedRequests)
+                .rejectedRequests(rejectedRequests)
+                .build();
+    }
+
     @Transactional
     public OBProfileResponse updateOBProfile(
             Long userId,
@@ -312,6 +353,19 @@ public class MypageService {
         mentor.updateVisibility(calculateMentorVisibility(mentor));
 
         return getOBSchedule(userId);
+    }
+
+    @Transactional
+    public void rejectOBMentoringRequest(Long userId, Long applicationId, ApplicationRejectRequest request) {
+        MentoringApplication application = mentoringApplicationRepository
+                .findByApplicationIdAndSlotMentorMemberUserId(applicationId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멘토링 신청입니다."));
+
+        if (application.getStatus() != ApplicationStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 멘토링 신청만 거절할 수 있습니다.");
+        }
+
+        application.reject(request.getRejectionReason().trim());
     }
 
     @Transactional

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -6,6 +6,8 @@ import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
 import com.kusitms.website.domain.mentoring.entity.MentoringReview;
 import com.kusitms.website.domain.mentoring.entity.MentoringReviewKeyword;
 import com.kusitms.website.domain.mentoring.entity.Mentor;
+import com.kusitms.website.domain.mentoring.entity.MentoringSlot;
+import com.kusitms.website.domain.mentoring.entity.SlotType;
 import com.kusitms.website.domain.mentoring.repository.MentorRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringApplicationRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringKeywordRepository;
@@ -16,9 +18,12 @@ import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.OBProfileVisibilityUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.OBScheduleUpdateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
+import com.kusitms.website.domain.user.dto.response.OBScheduleDateResponse;
+import com.kusitms.website.domain.user.dto.response.OBScheduleResponse;
 import com.kusitms.website.domain.user.dto.response.MyMentoringCardResponse;
 import com.kusitms.website.domain.user.dto.response.OBProfileResponse;
 import com.kusitms.website.domain.user.dto.response.YBMypageResponse;
@@ -30,8 +35,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -62,6 +73,9 @@ public class MypageService {
             Collections.singletonList(ApplicationStatus.ACTIVE);
     private static final List<ApplicationStatus> FINISHED_STATUSES =
             Arrays.asList(ApplicationStatus.COMPLETED, ApplicationStatus.REJECTED);
+    private static final List<ApplicationStatus> OCCUPYING_STATUSES =
+            Arrays.asList(ApplicationStatus.PENDING, ApplicationStatus.ACTIVE);
+    private static final LocalTime SLOT_START_MIN_TIME = LocalTime.of(9, 0);
 
     public YBMypageResponse getYBMypage(Long userId) {
         Member member = getActiveMember(userId);
@@ -161,6 +175,30 @@ public class MypageService {
         return OBProfileResponse.from(member, mentor);
     }
 
+    public OBScheduleResponse getOBSchedule(Long userId) {
+        Mentor mentor = getExistingMentor(userId);
+
+        List<MentoringSlot> slots = mentoringSlotRepository
+                .findByMentorMentorIdAndDateGreaterThanEqualOrderByDateAscStartTimeAsc(
+                        mentor.getMentorId(), LocalDate.now());
+
+        Map<Long, Integer> applicantCountMap = getApplicantCountMap(slots);
+        Map<LocalDate, List<MentoringSlot>> slotsByDate = slots.stream()
+                .collect(Collectors.groupingBy(
+                        MentoringSlot::getDate,
+                        LinkedHashMap::new,
+                        Collectors.toList()
+                ));
+
+        List<OBScheduleDateResponse> schedules = slotsByDate.entrySet().stream()
+                .map(entry -> OBScheduleDateResponse.from(entry.getKey(), entry.getValue(), applicantCountMap))
+                .collect(Collectors.toList());
+
+        return OBScheduleResponse.builder()
+                .schedules(schedules)
+                .build();
+    }
+
     @Transactional
     public OBProfileResponse updateOBProfile(
             Long userId,
@@ -207,13 +245,73 @@ public class MypageService {
     @Transactional
     public OBProfileResponse updateOBProfileVisibility(Long userId, OBProfileVisibilityUpdateRequest request) {
         Member member = getOBMember(userId);
-        Mentor mentor = mentorRepository.findByMemberUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("멘토 프로필을 먼저 작성해 주세요."));
+        Mentor mentor = getExistingMentor(userId);
 
         mentor.updateAcceptingRequests(request.getEnabled());
         mentor.updateVisibility(calculateMentorVisibility(mentor));
 
         return OBProfileResponse.from(member, mentor);
+    }
+
+    @Transactional
+    public OBScheduleResponse updateOBSchedule(Long userId, OBScheduleUpdateRequest request) {
+        Mentor mentor = getExistingMentor(userId);
+
+        validateScheduleRequest(mentor, request);
+
+        LocalDate date = request.getDate();
+        SlotType slotType = request.getGroupMentoring() ? SlotType.ONE_TO_N : SlotType.ONE_TO_ONE;
+        int maxAttendees = request.getGroupMentoring() ? request.getMaxAttendees() : 1;
+
+        List<LocalTime> sortedStartTimes = request.getStartTimes().stream()
+                .sorted()
+                .collect(Collectors.toList());
+
+        List<MentoringSlot> existingSlots = mentoringSlotRepository
+                .findByMentorMentorIdAndDateWithLock(mentor.getMentorId(), date);
+
+        Map<Long, Integer> applicantCountMap = getApplicantCountMap(existingSlots);
+        Map<LocalTime, MentoringSlot> existingSlotMap = existingSlots.stream()
+                .collect(Collectors.toMap(MentoringSlot::getStartTime, slot -> slot));
+        Set<LocalTime> requestedStartTimes = Set.copyOf(sortedStartTimes);
+
+        validateLockedSlots(existingSlots, applicantCountMap, requestedStartTimes, slotType, maxAttendees);
+
+        for (MentoringSlot existingSlot : existingSlots) {
+            if (applicantCountMap.getOrDefault(existingSlot.getSlotId(), 0) > 0) {
+                continue;
+            }
+
+            if (!requestedStartTimes.contains(existingSlot.getStartTime())) {
+                mentoringSlotRepository.delete(existingSlot);
+                continue;
+            }
+
+            existingSlot.updateSchedule(
+                    calculateEndTime(existingSlot.getStartTime(), mentor.getDurationMinutes()),
+                    slotType,
+                    maxAttendees
+            );
+        }
+
+        for (LocalTime startTime : sortedStartTimes) {
+            if (existingSlotMap.containsKey(startTime)) {
+                continue;
+            }
+
+            mentoringSlotRepository.save(MentoringSlot.builder()
+                    .mentor(mentor)
+                    .date(date)
+                    .startTime(startTime)
+                    .endTime(calculateEndTime(startTime, mentor.getDurationMinutes()))
+                    .slotType(slotType)
+                    .maxAttendees(maxAttendees)
+                    .build());
+        }
+
+        mentor.updateVisibility(calculateMentorVisibility(mentor));
+
+        return getOBSchedule(userId);
     }
 
     @Transactional
@@ -289,6 +387,12 @@ public class MypageService {
         return member;
     }
 
+    private Mentor getExistingMentor(Long userId) {
+        getOBMember(userId);
+        return mentorRepository.findByMemberUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("멘토 프로필을 먼저 작성해 주세요."));
+    }
+
     private boolean calculateMentorVisibility(Mentor mentor) {
         if (!mentor.isAcceptingRequests()) {
             return false;
@@ -298,6 +402,89 @@ public class MypageService {
         }
         return mentoringSlotRepository.existsByMentorMentorIdAndDateGreaterThanEqual(
                 mentor.getMentorId(), LocalDate.now());
+    }
+
+    private void validateScheduleRequest(Mentor mentor, OBScheduleUpdateRequest request) {
+        if (mentor.getDurationMinutes() == null) {
+            throw new IllegalArgumentException("멘토링 한타임 시간을 먼저 설정해 주세요.");
+        }
+        if (request.getDate().isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("오늘 이후 날짜만 등록할 수 있습니다.");
+        }
+        if (request.getGroupMentoring() && request.getMaxAttendees() == null) {
+            throw new IllegalArgumentException("소그룹 멘토링 최대 인원을 선택해 주세요.");
+        }
+
+        long distinctStartTimeCount = request.getStartTimes().stream().distinct().count();
+        if (distinctStartTimeCount != request.getStartTimes().size()) {
+            throw new IllegalArgumentException("중복된 시간 슬롯은 등록할 수 없습니다.");
+        }
+
+        for (LocalTime startTime : request.getStartTimes()) {
+            validateStartTime(startTime, mentor.getDurationMinutes());
+        }
+    }
+
+    private void validateStartTime(LocalTime startTime, int durationMinutes) {
+        if (startTime.isBefore(SLOT_START_MIN_TIME)) {
+            throw new IllegalArgumentException("시간 슬롯은 오전 9시 이후부터 등록할 수 있습니다.");
+        }
+        if (startTime.getMinute() % 10 != 0) {
+            throw new IllegalArgumentException("시간 슬롯은 10분 단위로만 등록할 수 있습니다.");
+        }
+
+        int startMinutes = startTime.getHour() * 60 + startTime.getMinute();
+        if (startMinutes + durationMinutes > 24 * 60) {
+            throw new IllegalArgumentException("자정을 넘는 시간 슬롯은 등록할 수 없습니다.");
+        }
+    }
+
+    private void validateLockedSlots(
+            List<MentoringSlot> existingSlots,
+            Map<Long, Integer> applicantCountMap,
+            Set<LocalTime> requestedStartTimes,
+            SlotType slotType,
+            int maxAttendees
+    ) {
+        boolean hasLockedSlot = existingSlots.stream()
+                .anyMatch(slot -> applicantCountMap.getOrDefault(slot.getSlotId(), 0) > 0);
+
+        if (!hasLockedSlot) {
+            return;
+        }
+
+        for (MentoringSlot slot : existingSlots) {
+            if (applicantCountMap.getOrDefault(slot.getSlotId(), 0) == 0) {
+                continue;
+            }
+            if (!requestedStartTimes.contains(slot.getStartTime())) {
+                throw new IllegalArgumentException("신청된 시간 슬롯은 삭제할 수 없습니다.");
+            }
+            if (slot.getSlotType() != slotType
+                    || (slotType == SlotType.ONE_TO_N && slot.getMaxAttendees() != maxAttendees)) {
+                throw new IllegalArgumentException("해당 날짜에 이미 신청한 멘티가 있어 변경할 수 없습니다.");
+            }
+        }
+    }
+
+    private Map<Long, Integer> getApplicantCountMap(List<MentoringSlot> slots) {
+        if (slots.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> slotIds = slots.stream()
+                .map(MentoringSlot::getSlotId)
+                .collect(Collectors.toList());
+
+        Map<Long, Integer> applicantCountMap = new HashMap<>();
+        mentoringApplicationRepository.countBySlotIdsAndStatusIn(slotIds, OCCUPYING_STATUSES)
+                .forEach(row -> applicantCountMap.put((Long) row[0], ((Long) row[1]).intValue()));
+
+        return applicantCountMap;
+    }
+
+    private LocalTime calculateEndTime(LocalTime startTime, int durationMinutes) {
+        return startTime.plusMinutes(durationMinutes);
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -49,6 +49,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import com.kusitms.website.domain.mentoring.dto.response.MentoringReviewListResponse;
+import com.kusitms.website.domain.mentoring.dto.response.MentoringReviewDetailResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -240,6 +242,15 @@ public class MypageService {
                 .build();
     }
 
+    public MentoringReviewListResponse getOBReceivedReviews(Long userId, int page) {
+        Mentor mentor = getExistingMentor(userId);
+
+        Page<MentoringReview> reviewPage = mentoringReviewRepository
+                .findByMentorMentorIdOrderByCreatedAtDesc(mentor.getMentorId(), PageRequest.of(page, 10));
+
+        return buildMentoringReviewListResponse(reviewPage);
+    }
+
     @Transactional
     public OBProfileResponse updateOBProfile(
             Long userId,
@@ -369,6 +380,33 @@ public class MypageService {
     }
 
     @Transactional
+    public void approveOBMentoringRequest(Long userId, Long applicationId) {
+        MentoringApplication application = mentoringApplicationRepository
+                .findByApplicationIdAndSlotMentorMemberUserId(applicationId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멘토링 신청입니다."));
+
+        if (application.getStatus() != ApplicationStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 멘토링 신청만 승인할 수 있습니다.");
+        }
+
+        MentoringSlot slot = mentoringSlotRepository.findByIdWithLock(application.getSlot().getSlotId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 슬롯입니다."));
+
+        int currentApplicants = mentoringApplicationRepository.countBySlotIdAndStatusIn(
+                slot.getSlotId(), OCCUPYING_STATUSES);
+
+        if (slot.getSlotType() == SlotType.ONE_TO_ONE && currentApplicants >= 1) {
+            throw new IllegalArgumentException("해당 시간대는 이미 예약되었습니다.");
+        }
+        if (slot.getSlotType() == SlotType.ONE_TO_N && currentApplicants >= slot.getMaxAttendees()) {
+            throw new IllegalArgumentException("해당 시간대의 최대 인원에 도달했습니다.");
+        }
+
+        application.approve();
+        slot.getMentor().updateVisibility(calculateMentorVisibility(slot.getMentor()));
+    }
+
+    @Transactional
     public AccountProfileResponse updateAccountProfile(
             Long userId,
             AccountProfileUpdateRequest request,
@@ -454,8 +492,7 @@ public class MypageService {
         if (!mentor.isProfileCompleted()) {
             return false;
         }
-        return mentoringSlotRepository.existsByMentorMentorIdAndDateGreaterThanEqual(
-                mentor.getMentorId(), LocalDate.now());
+        return hasAvailableFutureSlot(mentor);
     }
 
     private void validateScheduleRequest(Mentor mentor, OBScheduleUpdateRequest request) {
@@ -537,8 +574,41 @@ public class MypageService {
         return applicantCountMap;
     }
 
+    private boolean hasAvailableFutureSlot(Mentor mentor) {
+        List<MentoringSlot> futureSlots = mentoringSlotRepository
+                .findByMentorMentorIdAndDateGreaterThanEqualOrderByDateAscStartTimeAsc(
+                        mentor.getMentorId(), LocalDate.now());
+
+        if (futureSlots.isEmpty()) {
+            return false;
+        }
+
+        Map<Long, Integer> applicantCountMap = getApplicantCountMap(futureSlots);
+
+        return futureSlots.stream().anyMatch(slot -> {
+            int currentApplicants = applicantCountMap.getOrDefault(slot.getSlotId(), 0);
+            if (slot.getSlotType() == SlotType.ONE_TO_ONE) {
+                return currentApplicants < 1;
+            }
+            return currentApplicants < slot.getMaxAttendees();
+        });
+    }
+
     private LocalTime calculateEndTime(LocalTime startTime, int durationMinutes) {
         return startTime.plusMinutes(durationMinutes);
+    }
+
+    private MentoringReviewListResponse buildMentoringReviewListResponse(Page<MentoringReview> reviewPage) {
+        List<MentoringReviewDetailResponse> reviews = reviewPage.getContent().stream()
+                .map(MentoringReviewDetailResponse::from)
+                .collect(Collectors.toList());
+
+        return MentoringReviewListResponse.builder()
+                .totalCount(reviewPage.getTotalElements())
+                .totalPages(reviewPage.getTotalPages())
+                .currentPage(reviewPage.getNumber())
+                .reviews(reviews)
+                .build();
     }
 
     private void validateImageFile(MultipartFile file) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,12 +1,17 @@
 package com.kusitms.website.domain.user;
 
 import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import com.kusitms.website.domain.mentoring.entity.MentoringKeyword;
 import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
+import com.kusitms.website.domain.mentoring.entity.MentoringReview;
+import com.kusitms.website.domain.mentoring.entity.MentoringReviewKeyword;
 import com.kusitms.website.domain.mentoring.repository.MentorRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringApplicationRepository;
+import com.kusitms.website.domain.mentoring.repository.MentoringKeywordRepository;
 import com.kusitms.website.domain.mentoring.repository.MentoringReviewRepository;
 import com.kusitms.website.domain.file.S3Service;
 import com.kusitms.website.domain.user.dto.request.AccountProfileUpdateRequest;
+import com.kusitms.website.domain.user.dto.request.MentoringReviewCreateRequest;
 import com.kusitms.website.domain.user.dto.request.PasswordChangeRequest;
 import com.kusitms.website.domain.user.dto.response.AccountProfileResponse;
 import com.kusitms.website.domain.user.dto.response.ApplicationRejectionReasonResponse;
@@ -38,6 +43,7 @@ public class MypageService {
 
     private final MemberRepository memberRepository;
     private final MentoringApplicationRepository mentoringApplicationRepository;
+    private final MentoringKeywordRepository mentoringKeywordRepository;
     private final MentoringReviewRepository mentoringReviewRepository;
     private final MentorRepository mentorRepository;
     private final S3Service s3Service;
@@ -96,6 +102,45 @@ public class MypageService {
                 application.getApplicationId(),
                 application.getRejectionReason()
         );
+    }
+
+    @Transactional
+    public void createMentoringReview(Long userId, MentoringReviewCreateRequest request) {
+        MentoringApplication application = mentoringApplicationRepository
+                .findByApplicationIdAndApplicantUserId(request.getApplicationId(), userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멘토링 신청입니다."));
+
+        if (application.getStatus() != ApplicationStatus.COMPLETED) {
+            throw new IllegalArgumentException("완료된 멘토링에 한해서만 후기를 작성할 수 있습니다.");
+        }
+        if (mentoringReviewRepository.existsByApplicationApplicationId(application.getApplicationId())) {
+            throw new IllegalArgumentException("이미 후기가 작성된 멘토링입니다.");
+        }
+
+        List<Long> keywordIds = request.getKeywordIds();
+        long distinctKeywordCount = keywordIds.stream().distinct().count();
+        if (distinctKeywordCount != keywordIds.size()) {
+            throw new IllegalArgumentException("중복된 키워드는 선택할 수 없습니다.");
+        }
+
+        List<MentoringKeyword> keywords = mentoringKeywordRepository.findByKeywordIdIn(keywordIds);
+        if (keywords.size() != keywordIds.size()) {
+            throw new IllegalArgumentException("유효하지 않은 키워드가 포함되어 있습니다.");
+        }
+
+        MentoringReview review = MentoringReview.builder()
+                .mentor(application.getSlot().getMentor())
+                .reviewer(application.getApplicant())
+                .application(application)
+                .content(request.getContent())
+                .recommendationType(request.getRecommendationType())
+                .build();
+
+        for (MentoringKeyword keyword : keywords) {
+            review.addKeyword(new MentoringReviewKeyword(review, keyword));
+        }
+
+        mentoringReviewRepository.save(review);
     }
 
     public AccountProfileResponse getAccountProfile(Long userId) {

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/ApplicationRejectRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/ApplicationRejectRequest.java
@@ -1,0 +1,14 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class ApplicationRejectRequest {
+
+    @NotBlank(message = "거절 사유를 입력해 주세요.")
+    @Size(max = 300, message = "거절 사유는 300자 이하여야 합니다.")
+    private String rejectionReason;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/MentoringReviewCreateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/MentoringReviewCreateRequest.java
@@ -1,0 +1,34 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import com.kusitms.website.domain.mentoring.entity.RecommendationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "멘토링 후기 작성 요청")
+public class MentoringReviewCreateRequest {
+
+    @NotNull
+    @Schema(description = "멘토링 신청 ID", required = true)
+    private Long applicationId;
+
+    @NotEmpty
+    @Size(max = 3)
+    @Schema(description = "선택한 키워드 ID 목록", required = true)
+    private List<Long> keywordIds;
+
+    @Size(max = 1000)
+    @Schema(description = "자유 후기", maxLength = 1000)
+    private String content;
+
+    @NotNull
+    @Schema(description = "추천 여부", required = true)
+    private RecommendationType recommendationType;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/OBProfileUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/OBProfileUpdateRequest.java
@@ -1,0 +1,47 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import com.kusitms.website.domain.mentoring.entity.MentoringCategory;
+import com.kusitms.website.domain.mentoring.entity.MentoringMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "OB 프로필 수정 요청")
+public class OBProfileUpdateRequest {
+
+    @NotBlank
+    @Schema(description = "경력", required = true)
+    private String experience;
+
+    @NotBlank
+    @Schema(description = "멘토링 제목", required = true)
+    private String title;
+
+    @NotBlank
+    @Schema(description = "멘토링 소개", required = true)
+    private String introduction;
+
+    @NotNull
+    @Schema(description = "직무", required = true)
+    private MentoringCategory category;
+
+    @NotNull
+    @Schema(description = "멘토링 방식", required = true)
+    private MentoringMethod method;
+
+    @NotNull
+    @Min(30)
+    @Schema(description = "멘토링 한타임 시간(분)", required = true)
+    private Integer durationMinutes;
+
+    @NotNull
+    @Min(0)
+    @Schema(description = "멘토링 금액", required = true)
+    private Integer pricePerHour;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/OBProfileVisibilityUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/OBProfileVisibilityUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "OB 프로필 공개 토글 요청")
+public class OBProfileVisibilityUpdateRequest {
+
+    @NotNull
+    @Schema(description = "멘토링 신청 받기 여부", required = true)
+    private Boolean enabled;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/OBScheduleUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/OBScheduleUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.kusitms.website.domain.user.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+public class OBScheduleUpdateRequest {
+
+    @NotNull(message = "날짜는 필수입니다.")
+    private LocalDate date;
+
+    @NotNull(message = "소그룹 여부는 필수입니다.")
+    private Boolean groupMentoring;
+
+    @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")
+    @Max(value = 5, message = "최대 인원은 5명 이하여야 합니다.")
+    private Integer maxAttendees;
+
+    @NotEmpty(message = "최소 1개 이상의 시간 슬롯을 선택해 주세요.")
+    private List<LocalTime> startTimes;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/request/OBScheduleUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/request/OBScheduleUpdateRequest.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -23,6 +22,5 @@ public class OBScheduleUpdateRequest {
     @Max(value = 5, message = "최대 인원은 5명 이하여야 합니다.")
     private Integer maxAttendees;
 
-    @NotEmpty(message = "최소 1개 이상의 시간 슬롯을 선택해 주세요.")
     private List<LocalTime> startTimes;
 }

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/ApplicationRejectionReasonResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/ApplicationRejectionReasonResponse.java
@@ -1,0 +1,17 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "거절 사유 조회 응답")
+public class ApplicationRejectionReasonResponse {
+
+    @Schema(description = "멘토링 신청 ID")
+    private Long applicationId;
+
+    @Schema(description = "거절 사유")
+    private String rejectionReason;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/MyMentoringCardResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/MyMentoringCardResponse.java
@@ -1,0 +1,65 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@Schema(description = "마이페이지 멘토링 카드 응답")
+public class MyMentoringCardResponse {
+
+    @Schema(description = "멘토링 신청 ID")
+    private Long applicationId;
+
+    @Schema(description = "멘토 프로필 이미지 URL")
+    private String mentorProfileImageUrl;
+
+    @Schema(description = "멘토 이름")
+    private String mentorName;
+
+    @Schema(description = "멘토링 제목")
+    private String mentoringTitle;
+
+    @Schema(description = "멘토링 날짜")
+    private LocalDate date;
+
+    @Schema(description = "멘토링 시작 시간")
+    private LocalTime startTime;
+
+    @Schema(description = "멘토링 종료 시간")
+    private LocalTime endTime;
+
+    @Schema(description = "신청 상태")
+    private ApplicationStatus status;
+
+    @Schema(description = "채팅방 ID")
+    private Long chatRoomId;
+
+    @Schema(description = "후기 작성 가능 여부")
+    private boolean reviewWritable;
+
+    @Schema(description = "거절 사유 조회 가능 여부")
+    private boolean rejectionReasonVisible;
+
+    public static MyMentoringCardResponse from(MentoringApplication application, boolean reviewWritable) {
+        return MyMentoringCardResponse.builder()
+                .applicationId(application.getApplicationId())
+                .mentorProfileImageUrl(application.getSlot().getMentor().getProfileImageUrl())
+                .mentorName(application.getSlot().getMentor().getMember().getName())
+                .mentoringTitle(application.getSlot().getMentor().getTitle())
+                .date(application.getSlot().getDate())
+                .startTime(application.getSlot().getStartTime())
+                .endTime(application.getSlot().getEndTime())
+                .status(application.getStatus())
+                .chatRoomId(null)
+                .reviewWritable(reviewWritable)
+                .rejectionReasonVisible(application.getStatus() == ApplicationStatus.REJECTED)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBMentoringRequestCardResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBMentoringRequestCardResponse.java
@@ -1,0 +1,57 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@Schema(description = "OB 멘토링 요청 카드 응답")
+public class OBMentoringRequestCardResponse {
+
+    @Schema(description = "멘토링 신청 ID")
+    private Long applicationId;
+
+    @Schema(description = "멘티 프로필 이미지 URL")
+    private String menteeProfileImageUrl;
+
+    @Schema(description = "멘티 이름")
+    private String menteeName;
+
+    @Schema(description = "멘티 메시지")
+    private String message;
+
+    @Schema(description = "신청 날짜")
+    private LocalDate date;
+
+    @Schema(description = "신청 시작 시간")
+    private LocalTime startTime;
+
+    @Schema(description = "신청 종료 시간")
+    private LocalTime endTime;
+
+    @Schema(description = "신청 상태")
+    private ApplicationStatus status;
+
+    @Schema(description = "채팅방 ID")
+    private Long chatRoomId;
+
+    public static OBMentoringRequestCardResponse from(MentoringApplication application) {
+        return OBMentoringRequestCardResponse.builder()
+                .applicationId(application.getApplicationId())
+                .menteeProfileImageUrl(application.getApplicant().getProfileImageUrl())
+                .menteeName(application.getApplicant().getName())
+                .message(application.getMessage())
+                .date(application.getSlot().getDate())
+                .startTime(application.getSlot().getStartTime())
+                .endTime(application.getSlot().getEndTime())
+                .status(application.getStatus())
+                .chatRoomId(null)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBMentoringRequestsResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBMentoringRequestsResponse.java
@@ -1,0 +1,34 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "OB 멘토링 요청 목록 응답")
+public class OBMentoringRequestsResponse {
+
+    @Schema(description = "전체 요청 수")
+    private long totalCount;
+
+    @Schema(description = "전체 페이지 수")
+    private int totalPages;
+
+    @Schema(description = "현재 페이지")
+    private int currentPage;
+
+    @Schema(description = "대기 중 요청 목록")
+    private List<OBMentoringRequestCardResponse> pendingRequests;
+
+    @Schema(description = "진행 중 요청 목록")
+    private List<OBMentoringRequestCardResponse> activeRequests;
+
+    @Schema(description = "완료 요청 목록")
+    private List<OBMentoringRequestCardResponse> completedRequests;
+
+    @Schema(description = "거절 요청 목록")
+    private List<OBMentoringRequestCardResponse> rejectedRequests;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBProfileResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBProfileResponse.java
@@ -1,0 +1,77 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.mentoring.entity.Mentor;
+import com.kusitms.website.domain.mentoring.entity.MentoringCategory;
+import com.kusitms.website.domain.mentoring.entity.MentoringMethod;
+import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.Part;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "OB 프로필 조회 응답")
+public class OBProfileResponse {
+
+    @Schema(description = "계정 프로필 이미지 URL")
+    private String accountProfileImageUrl;
+
+    @Schema(description = "이름")
+    private String name;
+
+    @Schema(description = "기수")
+    private Integer cardinal;
+
+    @Schema(description = "파트")
+    private Part part;
+
+    @Schema(description = "멘토 카드용 프로필 이미지 URL")
+    private String mentorProfileImageUrl;
+
+    @Schema(description = "경력")
+    private String experience;
+
+    @Schema(description = "멘토링 제목")
+    private String title;
+
+    @Schema(description = "멘토링 소개")
+    private String introduction;
+
+    @Schema(description = "직무")
+    private MentoringCategory category;
+
+    @Schema(description = "멘토링 방식")
+    private MentoringMethod method;
+
+    @Schema(description = "멘토링 한타임 시간(분)")
+    private Integer durationMinutes;
+
+    @Schema(description = "멘토링 금액")
+    private Integer pricePerHour;
+
+    @Schema(description = "멘토링 신청 받기 토글 상태")
+    private boolean acceptingRequests;
+
+    @Schema(description = "실제 공개 여부")
+    private boolean visible;
+
+    public static OBProfileResponse from(Member member, Mentor mentor) {
+        return OBProfileResponse.builder()
+                .accountProfileImageUrl(member.getProfileImageUrl())
+                .name(member.getName())
+                .cardinal(member.getCardinal())
+                .part(member.getPart())
+                .mentorProfileImageUrl(mentor != null ? mentor.getProfileImageUrl() : null)
+                .experience(mentor != null ? mentor.getExperience() : null)
+                .title(mentor != null ? mentor.getTitle() : null)
+                .introduction(mentor != null ? mentor.getIntroduction() : null)
+                .category(mentor != null ? mentor.getCategory() : null)
+                .method(mentor != null ? mentor.getMethod() : null)
+                .durationMinutes(mentor != null ? mentor.getDurationMinutes() : null)
+                .pricePerHour(mentor != null ? mentor.getPricePerHour() : null)
+                .acceptingRequests(mentor != null && mentor.isAcceptingRequests())
+                .visible(mentor != null && mentor.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleDateResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleDateResponse.java
@@ -1,0 +1,36 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.mentoring.entity.MentoringSlot;
+import com.kusitms.website.domain.mentoring.entity.SlotType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class OBScheduleDateResponse {
+
+    private LocalDate date;
+    private boolean groupMentoring;
+    private int maxAttendees;
+    private List<OBScheduleSlotResponse> slots;
+
+    public static OBScheduleDateResponse from(LocalDate date, List<MentoringSlot> slots, Map<Long, Integer> applicantCountMap) {
+        SlotType slotType = slots.get(0).getSlotType();
+        int maxAttendees = slotType == SlotType.ONE_TO_N ? slots.get(0).getMaxAttendees() : 1;
+
+        return OBScheduleDateResponse.builder()
+                .date(date)
+                .groupMentoring(slotType == SlotType.ONE_TO_N)
+                .maxAttendees(maxAttendees)
+                .slots(slots.stream()
+                        .map(slot -> OBScheduleSlotResponse.from(
+                                slot, applicantCountMap.getOrDefault(slot.getSlotId(), 0)))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleResponse.java
@@ -1,0 +1,13 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OBScheduleResponse {
+
+    private List<OBScheduleDateResponse> schedules;
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleSlotResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/OBScheduleSlotResponse.java
@@ -1,0 +1,28 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import com.kusitms.website.domain.mentoring.entity.MentoringSlot;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class OBScheduleSlotResponse {
+
+    private Long slotId;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private int currentApplicants;
+    private boolean locked;
+
+    public static OBScheduleSlotResponse from(MentoringSlot slot, int currentApplicants) {
+        return OBScheduleSlotResponse.builder()
+                .slotId(slot.getSlotId())
+                .startTime(slot.getStartTime())
+                .endTime(slot.getEndTime())
+                .currentApplicants(currentApplicants)
+                .locked(currentApplicants > 0)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/user/dto/response/YBMypageResponse.java
+++ b/src/main/java/com/kusitms/website/domain/user/dto/response/YBMypageResponse.java
@@ -1,0 +1,25 @@
+package com.kusitms.website.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "YB 마이페이지 조회 응답")
+public class YBMypageResponse {
+
+    @Schema(description = "상단 프로필 정보")
+    private AccountProfileResponse profile;
+
+    @Schema(description = "대기 중 멘토링 목록")
+    private List<MyMentoringCardResponse> pendingMentorings;
+
+    @Schema(description = "진행 중 멘토링 목록")
+    private List<MyMentoringCardResponse> activeMentorings;
+
+    @Schema(description = "완료/거절 멘토링 목록")
+    private List<MyMentoringCardResponse> completedMentorings;
+}


### PR DESCRIPTION
### 관련 이슈
- Closed #53 

### 작업 내용
- YB 마이페이지 조회 API 구현
- 거절 사유 조회 API 구현
- 멘토링 후기 작성 API 구현
- OB 프로필 조회/수정 및 공개 토글 API 구현
- OB 가능 시간 조회/저장 API 구현
- OB 멘토링 요청 목록 조회, 승인/거절 API 구현
- OB 받은 후기 조회 API 구현

### 상세 변경 사항
- `MypageController`, `MypageService`에 YB/OB 마이페이지 관련 API를 확장했습니다.
- `GET /api/mypage` 추가
- `GET /api/mypage/applications/{applicationId}/rejection-reason` 추가
- `POST /api/mypage/reviews` 추가
- `GET /api/mypage/ob/profile` 추가
- `PUT /api/mypage/ob/profile` 추가
- `PUT /api/mypage/ob/profile/visibility` 추가
- `GET /api/mypage/ob/schedule` 추가
- `PUT /api/mypage/ob/schedule` 추가
- `GET /api/mypage/ob/requests` 추가
- `POST /api/mypage/ob/requests/{applicationId}/approve` 추가
- `POST /api/mypage/ob/requests/{applicationId}/reject` 추가
- `GET /api/mypage/ob/reviews` 추가
- `MentoringApplication`, `MentoringReview`, `Mentor`, `MentoringSlot` 엔티티에 마이페이지 요구사항 대응 필드를 반영했습니다.
- `MentoringApplicationRepository`, `MentoringReviewRepository`, `MentoringSlotRepository` 조회 메서드를 확장했습니다.

### 구현 포인트
- YB 마이페이지는 신청 상태를 `PENDING`, `ACTIVE`, `COMPLETED/REJECTED`로 분리해 응답하도록 구성했습니다.
- 후기 작성은 멘토링 신청과 `application_id`로 1:1 연결해 중복 작성이 불가능하도록 보장했습니다.
- `@EntityGraph`를 적용해 마이페이지 조회, OB 요청 목록 조회, 후기 조회 시 필요한 연관 엔티티를 함께 로딩하도록 구성했습니다.
- OB 프로필 공개 여부는 단순 토글이 아니라 프로필 작성 완료, 미래 슬롯 존재, 신청 받기 ON 조건을 함께 검사하도록 구현했습니다.
- 가능 시간 저장은 날짜 단위로 처리하되, 이미 신청이 걸린 슬롯은 삭제/타입 변경이 불가능하도록 보호 로직을 추가했습니다.
- 승인 API는 슬롯을 다시 락으로 조회한 뒤 현재 신청 수를 기준으로 정원 초과를 검증하고 `ACTIVE`로 변경하도록 구현했습니다.
- 슬롯/승인 상태 변경 이후 멘토 visibility를 재계산해, 신청 가능한 미래 슬롯이 없으면 자동 비공개되도록 반영했습니다.
- 후기 조회는 키워드, 작성자, 추천 여부까지 한 번에 내려줄 수 있도록 응답 구조를 정리했습니다.

### 테스트
- `./gradlew compileJava` 성공 확인

### 참고 사항
- 채팅방 생성 및 연결은 채팅 도메인 구현 전 단계라 이번 PR 범위에서 제외했습니다.
- 승인 API는 현재 레포 구조 기준으로 멘토링 상태 변경과 슬롯 정합성 검증까지 우선 반영했습니다.