### PR TITLE
feat: 채팅 API 및 WebSocket 실시간 통신 구현(#54)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kusitms/website/domain/chat/ChatController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatController.java
@@ -1,6 +1,8 @@
 package com.kusitms.website.domain.chat;
 
 import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
+import com.kusitms.website.domain.chat.dto.request.ChatScheduleUpdateRequest;
+import com.kusitms.website.domain.chat.dto.response.ChatCloseApproveResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseRequestResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
@@ -22,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -108,6 +111,32 @@ public class ChatController {
     public ResponseEntity<BaseResponse<ChatCloseRequestResponse>> requestCloseChatRoom(@PathVariable Long roomId) {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(chatService.requestCloseChatRoom(userId, roomId)));
+    }
+
+    @PostMapping("/rooms/{roomId}/close-approve")
+    @Operation(summary = "채팅 종료 승인", description = "상대방의 채팅 종료 요청을 승인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "승인 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "승인 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatCloseApproveResponse>> approveCloseChatRoom(@PathVariable Long roomId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.approveCloseChatRoom(userId, roomId)));
+    }
+
+    @PutMapping("/rooms/{roomId}/schedule")
+    @Operation(summary = "채팅 일정 수정", description = "OB 멘토가 채팅방의 멘토링 일정을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "수정 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatRoomDetailResponse>> updateSchedule(
+            @PathVariable Long roomId,
+            @RequestBody @Valid ChatScheduleUpdateRequest request) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.updateSchedule(userId, roomId, request)));
     }
 
     private Long getAuthenticatedUserId() {

--- a/src/main/java/com/kusitms/website/domain/chat/ChatController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatController.java
@@ -1,0 +1,61 @@
+package com.kusitms.website.domain.chat;
+
+import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
+import com.kusitms.website.domain.chat.service.ChatService;
+import com.kusitms.website.global.auth.UserPrincipal;
+import com.kusitms.website.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Tag(name = "Chat", description = "채팅 API")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @GetMapping("/rooms")
+    @Operation(summary = "채팅방 목록 조회", description = "로그인한 사용자의 채팅방 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+    })
+    public ResponseEntity<BaseResponse<ChatRoomListResponse>> getChatRooms() {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.getChatRooms(userId)));
+    }
+
+    @GetMapping("/rooms/{roomId}")
+    @Operation(summary = "채팅방 상세 조회", description = "로그인한 사용자의 채팅방 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatRoomDetailResponse>> getChatRoomDetail(@PathVariable Long roomId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.getChatRoomDetail(userId, roomId)));
+    }
+
+    private Long getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getPk();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/ChatController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatController.java
@@ -1,10 +1,14 @@
 package com.kusitms.website.domain.chat;
 
+import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
+import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
 import com.kusitms.website.domain.chat.service.ChatService;
 import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.common.BaseResponse;
+import javax.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,7 +19,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -47,6 +54,34 @@ public class ChatController {
     public ResponseEntity<BaseResponse<ChatRoomDetailResponse>> getChatRoomDetail(@PathVariable Long roomId) {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(chatService.getChatRoomDetail(userId, roomId)));
+    }
+
+    @GetMapping("/rooms/{roomId}/messages")
+    @Operation(summary = "채팅 메시지 목록 조회", description = "로그인한 사용자의 채팅 메시지를 커서 기반으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "조회 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatMessageSliceResponse>> getChatMessages(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long cursorId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.getChatMessages(userId, roomId, cursorId)));
+    }
+
+    @PostMapping("/rooms/{roomId}/messages")
+    @Operation(summary = "채팅 메시지 전송", description = "로그인한 사용자가 채팅방에 메시지를 전송합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전송 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "전송 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatMessageResponse>> sendMessage(
+            @PathVariable Long roomId,
+            @RequestBody @Valid ChatMessageSendRequest request) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.sendMessage(userId, roomId, request)));
     }
 
     private Long getAuthenticatedUserId() {

--- a/src/main/java/com/kusitms/website/domain/chat/ChatController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatController.java
@@ -1,8 +1,10 @@
 package com.kusitms.website.domain.chat;
 
 import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
+import com.kusitms.website.domain.chat.dto.response.ChatCloseRequestResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatReadResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
 import com.kusitms.website.domain.chat.service.ChatService;
@@ -82,6 +84,30 @@ public class ChatController {
             @RequestBody @Valid ChatMessageSendRequest request) {
         Long userId = getAuthenticatedUserId();
         return ResponseEntity.ok(new BaseResponse<>(chatService.sendMessage(userId, roomId, request)));
+    }
+
+    @PostMapping("/rooms/{roomId}/read")
+    @Operation(summary = "채팅 읽음 처리", description = "로그인한 사용자가 채팅방의 미읽음 메시지를 모두 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "처리 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "처리 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatReadResponse>> markMessagesAsRead(@PathVariable Long roomId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.markMessagesAsRead(userId, roomId)));
+    }
+
+    @PostMapping("/rooms/{roomId}/close-request")
+    @Operation(summary = "채팅 종료 요청", description = "로그인한 사용자가 채팅 종료를 요청합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "요청 불가"),
+    })
+    public ResponseEntity<BaseResponse<ChatCloseRequestResponse>> requestCloseChatRoom(@PathVariable Long roomId) {
+        Long userId = getAuthenticatedUserId();
+        return ResponseEntity.ok(new BaseResponse<>(chatService.requestCloseChatRoom(userId, roomId)));
     }
 
     private Long getAuthenticatedUserId() {

--- a/src/main/java/com/kusitms/website/domain/chat/ChatMessageController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatMessageController.java
@@ -1,0 +1,62 @@
+package com.kusitms.website.domain.chat;
+
+import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
+import com.kusitms.website.domain.chat.dto.request.ChatScheduleUpdateRequest;
+import com.kusitms.website.domain.chat.service.ChatService;
+import com.kusitms.website.global.auth.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.security.core.Authentication;
+
+@Controller
+@Validated
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/rooms/{roomId}/messages")
+    public void sendMessage(
+            @DestinationVariable Long roomId,
+            ChatMessageSendRequest request,
+            Authentication authentication
+    ) {
+        chatService.sendMessage(getAuthenticatedUserId(authentication), roomId, request);
+    }
+
+    @MessageMapping("/chat/rooms/{roomId}/read")
+    public void markMessagesAsRead(@DestinationVariable Long roomId, Authentication authentication) {
+        chatService.markMessagesAsRead(getAuthenticatedUserId(authentication), roomId);
+    }
+
+    @MessageMapping("/chat/rooms/{roomId}/close-request")
+    public void requestClose(@DestinationVariable Long roomId, Authentication authentication) {
+        chatService.requestCloseChatRoom(getAuthenticatedUserId(authentication), roomId);
+    }
+
+    @MessageMapping("/chat/rooms/{roomId}/close-approve")
+    public void approveClose(@DestinationVariable Long roomId, Authentication authentication) {
+        chatService.approveCloseChatRoom(getAuthenticatedUserId(authentication), roomId);
+    }
+
+    @MessageMapping("/chat/rooms/{roomId}/schedule")
+    public void updateSchedule(
+            @DestinationVariable Long roomId,
+            ChatScheduleUpdateRequest request,
+            Authentication authentication
+    ) {
+        chatService.updateSchedule(getAuthenticatedUserId(authentication), roomId, request);
+    }
+
+    private Long getAuthenticatedUserId(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            throw new IllegalArgumentException("로그인이 필요합니다.");
+        }
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        return principal.getPk();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/ChatMessageController.java
+++ b/src/main/java/com/kusitms/website/domain/chat/ChatMessageController.java
@@ -4,6 +4,7 @@ import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
 import com.kusitms.website.domain.chat.dto.request.ChatScheduleUpdateRequest;
 import com.kusitms.website.domain.chat.service.ChatService;
 import com.kusitms.website.global.auth.UserPrincipal;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -21,7 +22,7 @@ public class ChatMessageController {
     @MessageMapping("/chat/rooms/{roomId}/messages")
     public void sendMessage(
             @DestinationVariable Long roomId,
-            ChatMessageSendRequest request,
+            @Valid ChatMessageSendRequest request,
             Authentication authentication
     ) {
         chatService.sendMessage(getAuthenticatedUserId(authentication), roomId, request);
@@ -45,7 +46,7 @@ public class ChatMessageController {
     @MessageMapping("/chat/rooms/{roomId}/schedule")
     public void updateSchedule(
             @DestinationVariable Long roomId,
-            ChatScheduleUpdateRequest request,
+            @Valid ChatScheduleUpdateRequest request,
             Authentication authentication
     ) {
         chatService.updateSchedule(getAuthenticatedUserId(authentication), roomId, request);

--- a/src/main/java/com/kusitms/website/domain/chat/dto/request/ChatMessageSendRequest.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/request/ChatMessageSendRequest.java
@@ -1,0 +1,17 @@
+package com.kusitms.website.domain.chat.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+@Schema(description = "채팅 메시지 전송 요청")
+public class ChatMessageSendRequest {
+
+    @NotBlank(message = "메시지를 입력해 주세요.")
+    @Size(max = 1000, message = "메시지는 1000자 이하여야 합니다.")
+    @Schema(description = "메시지 내용", required = true, maxLength = 1000)
+    private String content;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/request/ChatScheduleUpdateRequest.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/request/ChatScheduleUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.kusitms.website.domain.chat.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Schema(description = "채팅 일정 수정 요청")
+public class ChatScheduleUpdateRequest {
+
+    @NotNull(message = "변경 날짜는 필수입니다.")
+    @Schema(description = "변경 날짜", required = true)
+    private LocalDate scheduledDate;
+
+    @NotNull(message = "변경 시작 시간은 필수입니다.")
+    @Schema(description = "변경 시작 시간", required = true)
+    private LocalTime scheduledStartTime;
+
+    @NotNull(message = "변경 종료 시간은 필수입니다.")
+    @Schema(description = "변경 종료 시간", required = true)
+    private LocalTime scheduledEndTime;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseActionStatus.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseActionStatus.java
@@ -1,0 +1,8 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+public enum ChatCloseActionStatus {
+    REQUEST,
+    REQUEST_PENDING,
+    APPROVE,
+    HIDDEN
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseApproveResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseApproveResponse.java
@@ -1,0 +1,25 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 종료 승인 응답")
+public class ChatCloseApproveResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "채팅방 상태")
+    private ChatRoomStatus roomStatus;
+
+    @Schema(description = "멘토링 신청 상태")
+    private ApplicationStatus applicationStatus;
+
+    @Schema(description = "종료 버튼 상태")
+    private ChatCloseActionStatus closeActionStatus;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseRequestResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseRequestResponse.java
@@ -1,0 +1,17 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 종료 요청 응답")
+public class ChatCloseRequestResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "종료 버튼 상태")
+    private ChatCloseActionStatus closeActionStatus;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseStateResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatCloseStateResponse.java
@@ -1,0 +1,36 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatCloseRequester;
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 종료 상태 응답")
+public class ChatCloseStateResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "채팅방 상태")
+    private ChatRoomStatus roomStatus;
+
+    @Schema(description = "종료 요청자")
+    private ChatCloseRequester closeRequester;
+
+    @Schema(description = "멘토링 신청 상태")
+    private ApplicationStatus applicationStatus;
+
+    public static ChatCloseStateResponse from(ChatRoom room) {
+        return new ChatCloseStateResponse(
+                room.getChatRoomId(),
+                room.getStatus(),
+                room.getCloseRequester(),
+                room.getApplication().getStatus()
+        );
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatEventType.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatEventType.java
@@ -1,0 +1,10 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+public enum ChatEventType {
+    MESSAGE_SENT,
+    MESSAGE_READ,
+    CLOSE_REQUESTED,
+    CLOSE_APPROVED,
+    SCHEDULE_UPDATED,
+    ROOM_LIST_UPDATED
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,52 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatMessage;
+import com.kusitms.website.domain.chat.entity.ChatMessageStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "채팅 메시지 응답")
+public class ChatMessageResponse {
+
+    @Schema(description = "메시지 ID")
+    private Long messageId;
+
+    @Schema(description = "발신자 ID")
+    private Long senderId;
+
+    @Schema(description = "발신자 이름")
+    private String senderName;
+
+    @Schema(description = "내가 보낸 메시지 여부")
+    private boolean mine;
+
+    @Schema(description = "메시지 내용")
+    private String content;
+
+    @Schema(description = "메시지 상태")
+    private ChatMessageStatus status;
+
+    @Schema(description = "상대방 읽음 여부")
+    private boolean readByRecipient;
+
+    @Schema(description = "전송 시각")
+    private LocalDateTime createdAt;
+
+    public static ChatMessageResponse from(ChatMessage message, Long userId) {
+        return ChatMessageResponse.builder()
+                .messageId(message.getChatMessageId())
+                .senderId(message.getSender().getUserId())
+                .senderName(message.getSender().getName())
+                .mine(message.getSender().getUserId().equals(userId))
+                .content(message.getContent())
+                .status(message.getStatus())
+                .readByRecipient(message.isReadByRecipient())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatMessageSliceResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatMessageSliceResponse.java
@@ -1,0 +1,22 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "채팅 메시지 목록 조회 응답")
+public class ChatMessageSliceResponse {
+
+    @Schema(description = "메시지 목록")
+    private List<ChatMessageResponse> messages;
+
+    @Schema(description = "다음 커서 ID")
+    private Long nextCursorId;
+
+    @Schema(description = "이전 메시지 추가 조회 가능 여부")
+    private boolean hasNext;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatReadResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatReadResponse.java
@@ -1,0 +1,17 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 읽음 처리 응답")
+public class ChatReadResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "읽음 처리된 메시지 수")
+    private int updatedCount;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,0 +1,63 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import com.kusitms.website.domain.mentoring.entity.MentoringMethod;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@Schema(description = "채팅방 상세 조회 응답")
+public class ChatRoomDetailResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "상대방 프로필 이미지 URL")
+    private String partnerProfileImageUrl;
+
+    @Schema(description = "상대방 이름")
+    private String partnerName;
+
+    @Schema(description = "멘토링 방식")
+    private MentoringMethod method;
+
+    @Schema(description = "멘토링 날짜")
+    private LocalDate scheduledDate;
+
+    @Schema(description = "멘토링 시작 시간")
+    private LocalTime scheduledStartTime;
+
+    @Schema(description = "멘토링 종료 시간")
+    private LocalTime scheduledEndTime;
+
+    @Schema(description = "읽기 전용 여부")
+    private boolean readOnly;
+
+    @Schema(description = "종료 버튼 상태")
+    private ChatCloseActionStatus closeActionStatus;
+
+    public static ChatRoomDetailResponse of(
+            ChatRoom room,
+            String partnerProfileImageUrl,
+            String partnerName,
+            ChatCloseActionStatus closeActionStatus
+    ) {
+        return ChatRoomDetailResponse.builder()
+                .roomId(room.getChatRoomId())
+                .partnerProfileImageUrl(partnerProfileImageUrl)
+                .partnerName(partnerName)
+                .method(room.getApplication().getSlot().getMentor().getMethod())
+                .scheduledDate(room.getScheduledDate())
+                .scheduledStartTime(room.getScheduledStartTime())
+                .scheduledEndTime(room.getScheduledEndTime())
+                .readOnly(room.getStatus() == ChatRoomStatus.READ_ONLY)
+                .closeActionStatus(closeActionStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomEventResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomEventResponse.java
@@ -1,0 +1,20 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 실시간 이벤트 응답")
+public class ChatRoomEventResponse {
+
+    @Schema(description = "이벤트 타입")
+    private ChatEventType eventType;
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "이벤트 데이터")
+    private Object payload;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomListItemResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomListItemResponse.java
@@ -1,0 +1,48 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "채팅방 목록 아이템 응답")
+public class ChatRoomListItemResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "상대방 프로필 이미지 URL")
+    private String partnerProfileImageUrl;
+
+    @Schema(description = "상대방 이름")
+    private String partnerName;
+
+    @Schema(description = "최근 메시지")
+    private String lastMessage;
+
+    @Schema(description = "최근 메시지 시각")
+    private LocalDateTime lastMessageAt;
+
+    @Schema(description = "미읽음 메시지 수")
+    private long unreadCount;
+
+    @Schema(description = "읽기 전용 여부")
+    private boolean readOnly;
+
+    public static ChatRoomListItemResponse of(ChatRoom room, String partnerProfileImageUrl, String partnerName, long unreadCount) {
+        return ChatRoomListItemResponse.builder()
+                .roomId(room.getChatRoomId())
+                .partnerProfileImageUrl(partnerProfileImageUrl)
+                .partnerName(partnerName)
+                .lastMessage(room.getLastMessage())
+                .lastMessageAt(room.getLastMessageAt())
+                .unreadCount(unreadCount)
+                .readOnly(room.getStatus() == ChatRoomStatus.READ_ONLY)
+                .build();
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,16 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "채팅방 목록 조회 응답")
+public class ChatRoomListResponse {
+
+    @Schema(description = "채팅방 목록")
+    private List<ChatRoomListItemResponse> rooms;
+}

--- a/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatScheduleUpdatedResponse.java
+++ b/src/main/java/com/kusitms/website/domain/chat/dto/response/ChatScheduleUpdatedResponse.java
@@ -1,0 +1,36 @@
+package com.kusitms.website.domain.chat.dto.response;
+
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "채팅 일정 수정 이벤트 응답")
+public class ChatScheduleUpdatedResponse {
+
+    @Schema(description = "채팅방 ID")
+    private Long roomId;
+
+    @Schema(description = "멘토링 날짜")
+    private LocalDate scheduledDate;
+
+    @Schema(description = "멘토링 시작 시간")
+    private LocalTime scheduledStartTime;
+
+    @Schema(description = "멘토링 종료 시간")
+    private LocalTime scheduledEndTime;
+
+    public static ChatScheduleUpdatedResponse from(ChatRoom room) {
+        return new ChatScheduleUpdatedResponse(
+                room.getChatRoomId(),
+                room.getScheduledDate(),
+                room.getScheduledStartTime(),
+                room.getScheduledEndTime()
+        );
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/entity/ChatCloseRequester.java
+++ b/src/main/java/com/kusitms/website/domain/chat/entity/ChatCloseRequester.java
@@ -1,0 +1,7 @@
+package com.kusitms.website.domain.chat.entity;
+
+public enum ChatCloseRequester {
+    NONE,
+    MENTEE,
+    MENTOR
+}

--- a/src/main/java/com/kusitms/website/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/kusitms/website/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,60 @@
+package com.kusitms.website.domain.chat.entity;
+
+import com.kusitms.website.domain.user.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @Column(name = "chat_message_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatMessageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @Column(columnDefinition = "TEXT", nullable = false, length = 1000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatMessageStatus status;
+
+    @Column(nullable = false)
+    private boolean readByRecipient;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ChatMessage(ChatRoom chatRoom, Member sender, String content,
+                       ChatMessageStatus status, boolean readByRecipient) {
+        this.chatRoom = chatRoom;
+        this.sender = sender;
+        this.content = content;
+        this.status = status;
+        this.readByRecipient = readByRecipient;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markAsRead() {
+        this.readByRecipient = true;
+    }
+
+    public void updateStatus(ChatMessageStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/entity/ChatMessageStatus.java
+++ b/src/main/java/com/kusitms/website/domain/chat/entity/ChatMessageStatus.java
@@ -1,0 +1,6 @@
+package com.kusitms.website.domain.chat.entity;
+
+public enum ChatMessageStatus {
+    SENT,
+    FAILED
+}

--- a/src/main/java/com/kusitms/website/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/kusitms/website/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,87 @@
+package com.kusitms.website.domain.chat.entity;
+
+import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @Column(name = "chat_room_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatRoomId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "application_id", nullable = false, unique = true)
+    private MentoringApplication application;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatRoomStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatCloseRequester closeRequester;
+
+    @Column(nullable = false)
+    private LocalDate scheduledDate;
+
+    @Column(nullable = false)
+    private LocalTime scheduledStartTime;
+
+    @Column(nullable = false)
+    private LocalTime scheduledEndTime;
+
+    @Column(length = 1000)
+    private String lastMessage;
+
+    private LocalDateTime lastMessageAt;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ChatRoom(MentoringApplication application, ChatRoomStatus status,
+                    ChatCloseRequester closeRequester, LocalDate scheduledDate,
+                    LocalTime scheduledStartTime, LocalTime scheduledEndTime) {
+        this.application = application;
+        this.status = status;
+        this.closeRequester = closeRequester;
+        this.scheduledDate = scheduledDate;
+        this.scheduledStartTime = scheduledStartTime;
+        this.scheduledEndTime = scheduledEndTime;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateLastMessage(String lastMessage, LocalDateTime lastMessageAt) {
+        this.lastMessage = lastMessage;
+        this.lastMessageAt = lastMessageAt;
+    }
+
+    public void requestClose(ChatCloseRequester closeRequester) {
+        this.closeRequester = closeRequester;
+    }
+
+    public void clearCloseRequest() {
+        this.closeRequester = ChatCloseRequester.NONE;
+    }
+
+    public void updateStatus(ChatRoomStatus status) {
+        this.status = status;
+    }
+
+    public void updateSchedule(LocalDate scheduledDate, LocalTime scheduledStartTime, LocalTime scheduledEndTime) {
+        this.scheduledDate = scheduledDate;
+        this.scheduledStartTime = scheduledStartTime;
+        this.scheduledEndTime = scheduledEndTime;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/entity/ChatRoomStatus.java
+++ b/src/main/java/com/kusitms/website/domain/chat/entity/ChatRoomStatus.java
@@ -1,0 +1,6 @@
+package com.kusitms.website.domain.chat.entity;
+
+public enum ChatRoomStatus {
+    ACTIVE,
+    READ_ONLY
+}

--- a/src/main/java/com/kusitms/website/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/kusitms/website/domain/chat/repository/ChatMessageRepository.java
@@ -30,6 +30,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             "AND cm.readByRecipient = false")
     long countUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
 
+    @Query("SELECT cm.chatRoom.chatRoomId AS chatRoomId, COUNT(cm) AS unreadCount " +
+            "FROM ChatMessage cm " +
+            "WHERE cm.chatRoom.chatRoomId IN :chatRoomIds " +
+            "AND cm.sender.userId <> :userId " +
+            "AND cm.readByRecipient = false " +
+            "GROUP BY cm.chatRoom.chatRoomId")
+    List<UnreadCountProjection> countUnreadMessagesByRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("userId") Long userId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE ChatMessage cm " +
             "SET cm.readByRecipient = true " +

--- a/src/main/java/com/kusitms/website/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/kusitms/website/domain/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,40 @@
+package com.kusitms.website.domain.chat.repository;
+
+import com.kusitms.website.domain.chat.entity.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    @EntityGraph(attributePaths = {"sender"})
+    Slice<ChatMessage> findByChatRoomChatRoomIdOrderByChatMessageIdDesc(Long chatRoomId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"sender"})
+    Slice<ChatMessage> findByChatRoomChatRoomIdAndChatMessageIdLessThanOrderByChatMessageIdDesc(
+            Long chatRoomId, Long cursorId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"sender"})
+    Optional<ChatMessage> findTopByChatRoomChatRoomIdOrderByChatMessageIdDesc(Long chatRoomId);
+
+    @Query("SELECT COUNT(cm) FROM ChatMessage cm " +
+            "WHERE cm.chatRoom.chatRoomId = :chatRoomId " +
+            "AND cm.sender.userId <> :userId " +
+            "AND cm.readByRecipient = false")
+    long countUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE ChatMessage cm " +
+            "SET cm.readByRecipient = true " +
+            "WHERE cm.chatRoom.chatRoomId = :chatRoomId " +
+            "AND cm.sender.userId <> :userId " +
+            "AND cm.readByRecipient = false")
+    int markAllAsRead(@Param("chatRoomId") Long chatRoomId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/kusitms/website/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kusitms/website/domain/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,50 @@
+package com.kusitms.website.domain.chat.repository;
+
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @EntityGraph(attributePaths = {
+            "application",
+            "application.slot",
+            "application.slot.mentor",
+            "application.slot.mentor.member",
+            "application.applicant"
+    })
+    Optional<ChatRoom> findByChatRoomId(Long chatRoomId);
+
+    @EntityGraph(attributePaths = {
+            "application",
+            "application.slot",
+            "application.slot.mentor",
+            "application.slot.mentor.member",
+            "application.applicant"
+    })
+    Optional<ChatRoom> findByApplicationApplicationId(Long applicationId);
+
+    @EntityGraph(attributePaths = {
+            "application",
+            "application.slot",
+            "application.slot.mentor",
+            "application.slot.mentor.member",
+            "application.applicant"
+    })
+    @Query("SELECT cr FROM ChatRoom cr " +
+            "WHERE cr.application.applicant.userId = :userId " +
+            "OR cr.application.slot.mentor.member.userId = :userId " +
+            "ORDER BY COALESCE(cr.lastMessageAt, cr.createdAt) DESC, cr.createdAt DESC")
+    List<ChatRoom> findAllByParticipantUserIdOrderByRecentMessage(@Param("userId") Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId = :chatRoomId")
+    Optional<ChatRoom> findByChatRoomIdWithLock(@Param("chatRoomId") Long chatRoomId);
+}

--- a/src/main/java/com/kusitms/website/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/kusitms/website/domain/chat/repository/ChatRoomRepository.java
@@ -47,4 +47,13 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT cr FROM ChatRoom cr WHERE cr.chatRoomId = :chatRoomId")
     Optional<ChatRoom> findByChatRoomIdWithLock(@Param("chatRoomId") Long chatRoomId);
+
+    @Query("SELECT CASE WHEN COUNT(cr) > 0 THEN true ELSE false END " +
+            "FROM ChatRoom cr " +
+            "WHERE cr.chatRoomId = :chatRoomId " +
+            "AND (cr.application.applicant.userId = :userId " +
+            "OR cr.application.slot.mentor.member.userId = :userId)")
+    boolean existsParticipantByChatRoomId(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("userId") Long userId);
 }

--- a/src/main/java/com/kusitms/website/domain/chat/repository/UnreadCountProjection.java
+++ b/src/main/java/com/kusitms/website/domain/chat/repository/UnreadCountProjection.java
@@ -1,0 +1,8 @@
+package com.kusitms.website.domain.chat.repository;
+
+public interface UnreadCountProjection {
+
+    Long getChatRoomId();
+
+    Long getUnreadCount();
+}

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -2,7 +2,9 @@ package com.kusitms.website.domain.chat.service;
 
 import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseActionStatus;
+import com.kusitms.website.domain.chat.dto.response.ChatCloseRequestResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatReadResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListItemResponse;
@@ -126,17 +128,52 @@ public class ChatService {
         return ChatMessageResponse.from(message, userId);
     }
 
+    @Transactional
+    public ChatReadResponse markMessagesAsRead(Long userId, Long roomId) {
+        ChatRoom room = getParticipatingRoom(userId, roomId);
+        int updatedCount = chatMessageRepository.markAllAsRead(room.getChatRoomId(), userId);
+        return new ChatReadResponse(room.getChatRoomId(), updatedCount);
+    }
+
+    @Transactional
+    public ChatCloseRequestResponse requestCloseChatRoom(Long userId, Long roomId) {
+        ChatRoom room = getParticipatingRoomWithLock(userId, roomId);
+
+        if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
+            throw new IllegalArgumentException("이미 종료된 채팅방입니다.");
+        }
+        if (room.getCloseRequester() != ChatCloseRequester.NONE) {
+            throw new IllegalArgumentException("이미 종료 요청이 진행 중인 채팅방입니다.");
+        }
+
+        room.requestClose(resolveCloseRequester(room, userId));
+
+        return new ChatCloseRequestResponse(
+                room.getChatRoomId(),
+                resolveCloseActionStatus(room, userId)
+        );
+    }
+
     private ChatRoom getParticipatingRoom(Long userId, Long roomId) {
         ChatRoom room = chatRoomRepository.findByChatRoomId(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+        validateParticipant(room, userId);
+        return room;
+    }
 
+    private ChatRoom getParticipatingRoomWithLock(Long userId, Long roomId) {
+        ChatRoom room = chatRoomRepository.findByChatRoomIdWithLock(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+        validateParticipant(room, userId);
+        return room;
+    }
+
+    private void validateParticipant(ChatRoom room, Long userId) {
         boolean isParticipant = room.getApplication().getApplicant().getUserId().equals(userId)
                 || room.getApplication().getSlot().getMentor().getMember().getUserId().equals(userId);
         if (!isParticipant) {
             throw new IllegalArgumentException("해당 채팅방에 접근할 수 없습니다.");
         }
-
-        return room;
     }
 
     private Map<Long, Long> getUnreadCountMap(List<ChatRoom> rooms, Long userId) {
@@ -186,5 +223,12 @@ public class ChatService {
         }
 
         return ChatCloseActionStatus.APPROVE;
+    }
+
+    private ChatCloseRequester resolveCloseRequester(ChatRoom room, Long userId) {
+        if (room.getApplication().getApplicant().getUserId().equals(userId)) {
+            return ChatCloseRequester.MENTEE;
+        }
+        return ChatCloseRequester.MENTOR;
     }
 }

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -1,0 +1,120 @@
+package com.kusitms.website.domain.chat.service;
+
+import com.kusitms.website.domain.chat.dto.response.ChatCloseActionStatus;
+import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatRoomListItemResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
+import com.kusitms.website.domain.chat.entity.ChatCloseRequester;
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import com.kusitms.website.domain.chat.repository.ChatMessageRepository;
+import com.kusitms.website.domain.chat.repository.ChatRoomRepository;
+import com.kusitms.website.domain.chat.repository.UnreadCountProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ChatRoomListResponse getChatRooms(Long userId) {
+        List<ChatRoom> rooms = chatRoomRepository.findAllByParticipantUserIdOrderByRecentMessage(userId);
+        Map<Long, Long> unreadCountMap = getUnreadCountMap(rooms, userId);
+
+        List<ChatRoomListItemResponse> responses = rooms.stream()
+                .map(room -> ChatRoomListItemResponse.of(
+                        room,
+                        getPartnerProfileImageUrl(room, userId),
+                        getPartnerName(room, userId),
+                        unreadCountMap.getOrDefault(room.getChatRoomId(), 0L)
+                ))
+                .collect(Collectors.toList());
+
+        return ChatRoomListResponse.builder()
+                .rooms(responses)
+                .build();
+    }
+
+    public ChatRoomDetailResponse getChatRoomDetail(Long userId, Long roomId) {
+        ChatRoom room = getParticipatingRoom(userId, roomId);
+
+        return ChatRoomDetailResponse.of(
+                room,
+                getPartnerProfileImageUrl(room, userId),
+                getPartnerName(room, userId),
+                resolveCloseActionStatus(room, userId)
+        );
+    }
+
+    private ChatRoom getParticipatingRoom(Long userId, Long roomId) {
+        ChatRoom room = chatRoomRepository.findByChatRoomId(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+
+        boolean isParticipant = room.getApplication().getApplicant().getUserId().equals(userId)
+                || room.getApplication().getSlot().getMentor().getMember().getUserId().equals(userId);
+        if (!isParticipant) {
+            throw new IllegalArgumentException("해당 채팅방에 접근할 수 없습니다.");
+        }
+
+        return room;
+    }
+
+    private Map<Long, Long> getUnreadCountMap(List<ChatRoom> rooms, Long userId) {
+        if (rooms.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> roomIds = rooms.stream()
+                .map(ChatRoom::getChatRoomId)
+                .collect(Collectors.toList());
+
+        return chatMessageRepository.countUnreadMessagesByRoomIds(roomIds, userId).stream()
+                .collect(Collectors.toMap(
+                        UnreadCountProjection::getChatRoomId,
+                        UnreadCountProjection::getUnreadCount
+                ));
+    }
+
+    private String getPartnerProfileImageUrl(ChatRoom room, Long userId) {
+        if (room.getApplication().getApplicant().getUserId().equals(userId)) {
+            return room.getApplication().getSlot().getMentor().getMember().getProfileImageUrl();
+        }
+        return room.getApplication().getApplicant().getProfileImageUrl();
+    }
+
+    private String getPartnerName(ChatRoom room, Long userId) {
+        if (room.getApplication().getApplicant().getUserId().equals(userId)) {
+            return room.getApplication().getSlot().getMentor().getMember().getName();
+        }
+        return room.getApplication().getApplicant().getName();
+    }
+
+    private ChatCloseActionStatus resolveCloseActionStatus(ChatRoom room, Long userId) {
+        if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
+            return ChatCloseActionStatus.HIDDEN;
+        }
+
+        boolean isMentee = room.getApplication().getApplicant().getUserId().equals(userId);
+
+        if (room.getCloseRequester() == ChatCloseRequester.NONE) {
+            return ChatCloseActionStatus.REQUEST;
+        }
+
+        if ((isMentee && room.getCloseRequester() == ChatCloseRequester.MENTEE)
+                || (!isMentee && room.getCloseRequester() == ChatCloseRequester.MENTOR)) {
+            return ChatCloseActionStatus.REQUEST_PENDING;
+        }
+
+        return ChatCloseActionStatus.APPROVE;
+    }
+}

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -1,20 +1,30 @@
 package com.kusitms.website.domain.chat.service;
 
+import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseActionStatus;
+import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListItemResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
 import com.kusitms.website.domain.chat.entity.ChatCloseRequester;
+import com.kusitms.website.domain.chat.entity.ChatMessage;
+import com.kusitms.website.domain.chat.entity.ChatMessageStatus;
 import com.kusitms.website.domain.chat.entity.ChatRoom;
 import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
 import com.kusitms.website.domain.chat.repository.ChatMessageRepository;
 import com.kusitms.website.domain.chat.repository.ChatRoomRepository;
 import com.kusitms.website.domain.chat.repository.UnreadCountProjection;
+import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,8 +34,11 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ChatService {
 
+    private static final int MESSAGE_PAGE_SIZE = 50;
+
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final MemberRepository memberRepository;
 
     public ChatRoomListResponse getChatRooms(Long userId) {
         List<ChatRoom> rooms = chatRoomRepository.findAllByParticipantUserIdOrderByRecentMessage(userId);
@@ -54,6 +67,63 @@ public class ChatService {
                 getPartnerName(room, userId),
                 resolveCloseActionStatus(room, userId)
         );
+    }
+
+    public ChatMessageSliceResponse getChatMessages(Long userId, Long roomId, Long cursorId) {
+        ChatRoom room = getParticipatingRoom(userId, roomId);
+
+        Slice<ChatMessage> messageSlice;
+        if (cursorId == null) {
+            messageSlice = chatMessageRepository.findByChatRoomChatRoomIdOrderByChatMessageIdDesc(
+                    room.getChatRoomId(), PageRequest.of(0, MESSAGE_PAGE_SIZE));
+        } else {
+            messageSlice = chatMessageRepository.findByChatRoomChatRoomIdAndChatMessageIdLessThanOrderByChatMessageIdDesc(
+                    room.getChatRoomId(), cursorId, PageRequest.of(0, MESSAGE_PAGE_SIZE));
+        }
+
+        List<ChatMessageResponse> messages = messageSlice.getContent().stream()
+                .sorted(Comparator.comparing(ChatMessage::getChatMessageId))
+                .map(message -> ChatMessageResponse.from(message, userId))
+                .collect(Collectors.toList());
+
+        Long nextCursorId = messageSlice.hasNext() && !messageSlice.getContent().isEmpty()
+                ? messageSlice.getContent().get(messageSlice.getContent().size() - 1).getChatMessageId()
+                : null;
+
+        return ChatMessageSliceResponse.builder()
+                .messages(messages)
+                .nextCursorId(nextCursorId)
+                .hasNext(messageSlice.hasNext())
+                .build();
+    }
+
+    @Transactional
+    public ChatMessageResponse sendMessage(Long userId, Long roomId, ChatMessageSendRequest request) {
+        ChatRoom room = getParticipatingRoom(userId, roomId);
+
+        if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
+            throw new IllegalArgumentException("읽기 전용 채팅방에는 메시지를 전송할 수 없습니다.");
+        }
+
+        String normalizedContent = request.getContent().trim();
+        if (normalizedContent.isEmpty()) {
+            throw new IllegalArgumentException("메시지를 입력해 주세요.");
+        }
+
+        Member sender = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        ChatMessage message = chatMessageRepository.save(ChatMessage.builder()
+                .chatRoom(room)
+                .sender(sender)
+                .content(normalizedContent)
+                .status(ChatMessageStatus.SENT)
+                .readByRecipient(false)
+                .build());
+
+        room.updateLastMessage(message.getContent(), message.getCreatedAt());
+
+        return ChatMessageResponse.from(message, userId);
     }
 
     private ChatRoom getParticipatingRoom(Long userId, Long roomId) {

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -1,7 +1,9 @@
 package com.kusitms.website.domain.chat.service;
 
 import com.kusitms.website.domain.chat.dto.request.ChatMessageSendRequest;
+import com.kusitms.website.domain.chat.dto.request.ChatScheduleUpdateRequest;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseActionStatus;
+import com.kusitms.website.domain.chat.dto.response.ChatCloseApproveResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseRequestResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatReadResponse;
@@ -17,7 +19,9 @@ import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
 import com.kusitms.website.domain.chat.repository.ChatMessageRepository;
 import com.kusitms.website.domain.chat.repository.ChatRoomRepository;
 import com.kusitms.website.domain.chat.repository.UnreadCountProjection;
+import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
 import com.kusitms.website.domain.user.Member;
+import com.kusitms.website.domain.user.MemberRole;
 import com.kusitms.website.domain.user.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -25,6 +29,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -150,6 +155,74 @@ public class ChatService {
 
         return new ChatCloseRequestResponse(
                 room.getChatRoomId(),
+                resolveCloseActionStatus(room, userId)
+        );
+    }
+
+    @Transactional
+    public ChatCloseApproveResponse approveCloseChatRoom(Long userId, Long roomId) {
+        ChatRoom room = getParticipatingRoomWithLock(userId, roomId);
+
+        if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
+            throw new IllegalArgumentException("이미 종료된 채팅방입니다.");
+        }
+        if (room.getCloseRequester() == ChatCloseRequester.NONE) {
+            throw new IllegalArgumentException("종료 요청이 없는 채팅방입니다.");
+        }
+        if (room.getCloseRequester() == resolveCloseRequester(room, userId)) {
+            throw new IllegalArgumentException("내가 요청한 종료는 직접 승인할 수 없습니다.");
+        }
+
+        room.getApplication().complete();
+        room.updateStatus(ChatRoomStatus.READ_ONLY);
+        room.clearCloseRequest();
+
+        return new ChatCloseApproveResponse(
+                room.getChatRoomId(),
+                room.getStatus(),
+                room.getApplication().getStatus(),
+                resolveCloseActionStatus(room, userId)
+        );
+    }
+
+    @Transactional
+    public ChatRoomDetailResponse updateSchedule(Long userId, Long roomId, ChatScheduleUpdateRequest request) {
+        ChatRoom room = getParticipatingRoomWithLock(userId, roomId);
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (member.getRole() != MemberRole.OB) {
+            throw new IllegalArgumentException("OB 회원만 일정을 수정할 수 있습니다.");
+        }
+        if (!room.getApplication().getSlot().getMentor().getMember().getUserId().equals(userId)) {
+            throw new IllegalArgumentException("멘토만 일정을 수정할 수 있습니다.");
+        }
+        if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
+            throw new IllegalArgumentException("읽기 전용 채팅방의 일정은 수정할 수 없습니다.");
+        }
+
+        LocalDateTime scheduledDateTime = LocalDateTime.of(
+                request.getScheduledDate(),
+                request.getScheduledStartTime()
+        );
+        if (!scheduledDateTime.isAfter(LocalDateTime.now())) {
+            throw new IllegalArgumentException("현재 이후의 일정을 입력해 주세요.");
+        }
+        if (!request.getScheduledEndTime().isAfter(request.getScheduledStartTime())) {
+            throw new IllegalArgumentException("종료 시간은 시작 시간보다 이후여야 합니다.");
+        }
+
+        room.updateSchedule(
+                request.getScheduledDate(),
+                request.getScheduledStartTime(),
+                request.getScheduledEndTime()
+        );
+
+        return ChatRoomDetailResponse.of(
+                room,
+                getPartnerProfileImageUrl(room, userId),
+                getPartnerName(room, userId),
                 resolveCloseActionStatus(room, userId)
         );
     }

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -5,12 +5,16 @@ import com.kusitms.website.domain.chat.dto.request.ChatScheduleUpdateRequest;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseActionStatus;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseApproveResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatCloseRequestResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatCloseStateResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatEventType;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatReadResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatMessageSliceResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatRoomEventResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomDetailResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListItemResponse;
 import com.kusitms.website.domain.chat.dto.response.ChatRoomListResponse;
+import com.kusitms.website.domain.chat.dto.response.ChatScheduleUpdatedResponse;
 import com.kusitms.website.domain.chat.entity.ChatCloseRequester;
 import com.kusitms.website.domain.chat.entity.ChatMessage;
 import com.kusitms.website.domain.chat.entity.ChatMessageStatus;
@@ -26,6 +30,7 @@ import com.kusitms.website.domain.user.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,6 +51,7 @@ public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final MemberRepository memberRepository;
+    private final SimpMessagingTemplate messagingTemplate;
 
     public ChatRoomListResponse getChatRooms(Long userId) {
         List<ChatRoom> rooms = chatRoomRepository.findAllByParticipantUserIdOrderByRecentMessage(userId);
@@ -130,14 +136,20 @@ public class ChatService {
 
         room.updateLastMessage(message.getContent(), message.getCreatedAt());
 
-        return ChatMessageResponse.from(message, userId);
+        ChatMessageResponse response = ChatMessageResponse.from(message, userId);
+        publishRoomEvent(room.getChatRoomId(), ChatEventType.MESSAGE_SENT, response);
+        publishRoomListUpdates(room);
+        return response;
     }
 
     @Transactional
     public ChatReadResponse markMessagesAsRead(Long userId, Long roomId) {
         ChatRoom room = getParticipatingRoom(userId, roomId);
         int updatedCount = chatMessageRepository.markAllAsRead(room.getChatRoomId(), userId);
-        return new ChatReadResponse(room.getChatRoomId(), updatedCount);
+        ChatReadResponse response = new ChatReadResponse(room.getChatRoomId(), updatedCount);
+        publishRoomEvent(room.getChatRoomId(), ChatEventType.MESSAGE_READ, response);
+        publishRoomListUpdates(room);
+        return response;
     }
 
     @Transactional
@@ -153,10 +165,12 @@ public class ChatService {
 
         room.requestClose(resolveCloseRequester(room, userId));
 
-        return new ChatCloseRequestResponse(
+        ChatCloseRequestResponse response = new ChatCloseRequestResponse(
                 room.getChatRoomId(),
                 resolveCloseActionStatus(room, userId)
         );
+        publishRoomEvent(room.getChatRoomId(), ChatEventType.CLOSE_REQUESTED, ChatCloseStateResponse.from(room));
+        return response;
     }
 
     @Transactional
@@ -177,12 +191,15 @@ public class ChatService {
         room.updateStatus(ChatRoomStatus.READ_ONLY);
         room.clearCloseRequest();
 
-        return new ChatCloseApproveResponse(
+        ChatCloseApproveResponse response = new ChatCloseApproveResponse(
                 room.getChatRoomId(),
                 room.getStatus(),
                 room.getApplication().getStatus(),
                 resolveCloseActionStatus(room, userId)
         );
+        publishRoomEvent(room.getChatRoomId(), ChatEventType.CLOSE_APPROVED, ChatCloseStateResponse.from(room));
+        publishRoomListUpdates(room);
+        return response;
     }
 
     @Transactional
@@ -219,12 +236,14 @@ public class ChatService {
                 request.getScheduledEndTime()
         );
 
-        return ChatRoomDetailResponse.of(
+        ChatRoomDetailResponse response = ChatRoomDetailResponse.of(
                 room,
                 getPartnerProfileImageUrl(room, userId),
                 getPartnerName(room, userId),
                 resolveCloseActionStatus(room, userId)
         );
+        publishRoomEvent(room.getChatRoomId(), ChatEventType.SCHEDULE_UPDATED, ChatScheduleUpdatedResponse.from(room));
+        return response;
     }
 
     private ChatRoom getParticipatingRoom(Long userId, Long roomId) {
@@ -303,5 +322,45 @@ public class ChatService {
             return ChatCloseRequester.MENTEE;
         }
         return ChatCloseRequester.MENTOR;
+    }
+
+    private void publishRoomEvent(Long roomId, ChatEventType eventType, Object payload) {
+        messagingTemplate.convertAndSend(
+                "/sub/chat/rooms/" + roomId,
+                new ChatRoomEventResponse(eventType, roomId, payload)
+        );
+    }
+
+    private void publishRoomListUpdates(ChatRoom room) {
+        Long applicantUserId = room.getApplication().getApplicant().getUserId();
+        Long mentorUserId = room.getApplication().getSlot().getMentor().getMember().getUserId();
+
+        messagingTemplate.convertAndSend(
+                "/sub/chat/users/" + applicantUserId + "/rooms",
+                new ChatRoomEventResponse(
+                        ChatEventType.ROOM_LIST_UPDATED,
+                        room.getChatRoomId(),
+                        buildChatRoomListItem(room, applicantUserId)
+                )
+        );
+
+        messagingTemplate.convertAndSend(
+                "/sub/chat/users/" + mentorUserId + "/rooms",
+                new ChatRoomEventResponse(
+                        ChatEventType.ROOM_LIST_UPDATED,
+                        room.getChatRoomId(),
+                        buildChatRoomListItem(room, mentorUserId)
+                )
+        );
+    }
+
+    private ChatRoomListItemResponse buildChatRoomListItem(ChatRoom room, Long userId) {
+        long unreadCount = chatMessageRepository.countUnreadMessages(room.getChatRoomId(), userId);
+        return ChatRoomListItemResponse.of(
+                room,
+                getPartnerProfileImageUrl(room, userId),
+                getPartnerName(room, userId),
+                unreadCount
+        );
     }
 }

--- a/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
+++ b/src/main/java/com/kusitms/website/domain/chat/service/ChatService.java
@@ -112,16 +112,13 @@ public class ChatService {
 
     @Transactional
     public ChatMessageResponse sendMessage(Long userId, Long roomId, ChatMessageSendRequest request) {
-        ChatRoom room = getParticipatingRoom(userId, roomId);
+        ChatRoom room = getParticipatingRoomWithLock(userId, roomId);
 
         if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
             throw new IllegalArgumentException("읽기 전용 채팅방에는 메시지를 전송할 수 없습니다.");
         }
 
-        String normalizedContent = request.getContent().trim();
-        if (normalizedContent.isEmpty()) {
-            throw new IllegalArgumentException("메시지를 입력해 주세요.");
-        }
+        String normalizedContent = validateAndNormalizeMessageContent(request);
 
         Member sender = memberRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
@@ -218,6 +215,8 @@ public class ChatService {
         if (room.getStatus() == ChatRoomStatus.READ_ONLY) {
             throw new IllegalArgumentException("읽기 전용 채팅방의 일정은 수정할 수 없습니다.");
         }
+
+        validateScheduleRequest(request);
 
         LocalDateTime scheduledDateTime = LocalDateTime.of(
                 request.getScheduledDate(),
@@ -322,6 +321,30 @@ public class ChatService {
             return ChatCloseRequester.MENTEE;
         }
         return ChatCloseRequester.MENTOR;
+    }
+
+    private String validateAndNormalizeMessageContent(ChatMessageSendRequest request) {
+        if (request == null || request.getContent() == null) {
+            throw new IllegalArgumentException("메시지를 입력해 주세요.");
+        }
+
+        String normalizedContent = request.getContent().trim();
+        if (normalizedContent.isEmpty()) {
+            throw new IllegalArgumentException("메시지를 입력해 주세요.");
+        }
+        if (normalizedContent.length() > 1000) {
+            throw new IllegalArgumentException("메시지는 1000자 이하여야 합니다.");
+        }
+        return normalizedContent;
+    }
+
+    private void validateScheduleRequest(ChatScheduleUpdateRequest request) {
+        if (request == null
+                || request.getScheduledDate() == null
+                || request.getScheduledStartTime() == null
+                || request.getScheduledEndTime() == null) {
+            throw new IllegalArgumentException("변경 일정은 날짜와 시간을 모두 입력해 주세요.");
+        }
     }
 
     private void publishRoomEvent(Long roomId, ChatEventType eventType, Object payload) {

--- a/src/main/java/com/kusitms/website/domain/user/MypageService.java
+++ b/src/main/java/com/kusitms/website/domain/user/MypageService.java
@@ -1,5 +1,9 @@
 package com.kusitms.website.domain.user;
 
+import com.kusitms.website.domain.chat.entity.ChatCloseRequester;
+import com.kusitms.website.domain.chat.entity.ChatRoom;
+import com.kusitms.website.domain.chat.entity.ChatRoomStatus;
+import com.kusitms.website.domain.chat.repository.ChatRoomRepository;
 import com.kusitms.website.domain.mentoring.entity.ApplicationStatus;
 import com.kusitms.website.domain.mentoring.entity.MentoringKeyword;
 import com.kusitms.website.domain.mentoring.entity.MentoringApplication;
@@ -70,6 +74,7 @@ public class MypageService {
     private final MentoringReviewRepository mentoringReviewRepository;
     private final MentorRepository mentorRepository;
     private final MentoringSlotRepository mentoringSlotRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final S3Service s3Service;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
@@ -416,7 +421,19 @@ public class MypageService {
             throw new IllegalArgumentException("해당 시간대의 최대 인원에 도달했습니다.");
         }
 
+        if (chatRoomRepository.findByApplicationApplicationId(application.getApplicationId()).isPresent()) {
+            throw new IllegalArgumentException("이미 채팅방이 생성된 멘토링 신청입니다.");
+        }
+
         application.approve();
+        chatRoomRepository.save(ChatRoom.builder()
+                .application(application)
+                .status(ChatRoomStatus.ACTIVE)
+                .closeRequester(ChatCloseRequester.NONE)
+                .scheduledDate(slot.getDate())
+                .scheduledStartTime(slot.getStartTime())
+                .scheduledEndTime(slot.getEndTime())
+                .build());
         slot.getMentor().updateVisibility(calculateMentorVisibility(slot.getMentor()));
     }
 

--- a/src/main/java/com/kusitms/website/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http.authorizeRequests()
                 .antMatchers("/api/**",
+                        "/ws/**",
                         "/swagger-ui/**",
                         "/api-docs",
                         "/swagger-resources/**",

--- a/src/main/java/com/kusitms/website/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/WebSocketConfig.java
@@ -1,0 +1,70 @@
+package com.kusitms.website.global.config;
+
+import com.kusitms.website.global.auth.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                if (accessor == null) {
+                    return message;
+                }
+
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    String authorization = accessor.getFirstNativeHeader("Authorization");
+                    if (!StringUtils.hasText(authorization) || !authorization.startsWith("Bearer ")) {
+                        throw new IllegalArgumentException("웹소켓 인증 토큰이 필요합니다.");
+                    }
+
+                    String token = authorization.substring(7);
+                    if (!jwtTokenProvider.validateToken(token)) {
+                        throw new IllegalArgumentException("유효하지 않은 웹소켓 토큰입니다.");
+                    }
+
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    accessor.setUser(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+
+                return message;
+            }
+        });
+    }
+}

--- a/src/main/java/com/kusitms/website/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kusitms/website/global/config/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package com.kusitms.website.global.config;
 
+import com.kusitms.website.domain.chat.repository.ChatRoomRepository;
+import com.kusitms.website.global.auth.UserPrincipal;
 import com.kusitms.website.global.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +26,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final ChatRoomRepository chatRoomRepository;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -63,8 +66,57 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 }
 
+                if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                    Authentication authentication = (Authentication) accessor.getUser();
+                    validateSubscription(authentication, accessor.getDestination());
+                }
+
                 return message;
             }
         });
+    }
+
+    private void validateSubscription(Authentication authentication, String destination) {
+        if (authentication == null || !authentication.isAuthenticated()
+                || !(authentication.getPrincipal() instanceof UserPrincipal)) {
+            throw new IllegalArgumentException("웹소켓 인증 정보가 올바르지 않습니다.");
+        }
+        if (!StringUtils.hasText(destination)) {
+            throw new IllegalArgumentException("구독 대상이 올바르지 않습니다.");
+        }
+
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        Long userId = principal.getPk();
+
+        if (destination.startsWith("/sub/chat/users/")) {
+            String prefix = "/sub/chat/users/";
+            String suffix = "/rooms";
+            if (!destination.endsWith(suffix)) {
+                throw new IllegalArgumentException("구독 대상이 올바르지 않습니다.");
+            }
+
+            String targetUserId = destination.substring(prefix.length(), destination.length() - suffix.length());
+            if (!String.valueOf(userId).equals(targetUserId)) {
+                throw new IllegalArgumentException("다른 사용자의 채팅 목록은 구독할 수 없습니다.");
+            }
+            return;
+        }
+
+        if (destination.startsWith("/sub/chat/rooms/")) {
+            String roomIdValue = destination.substring("/sub/chat/rooms/".length());
+            Long roomId;
+            try {
+                roomId = Long.valueOf(roomIdValue);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("구독 대상 채팅방이 올바르지 않습니다.");
+            }
+
+            if (!chatRoomRepository.existsParticipantByChatRoomId(roomId, userId)) {
+                throw new IllegalArgumentException("해당 채팅방을 구독할 수 없습니다.");
+            }
+            return;
+        }
+
+        throw new IllegalArgumentException("허용되지 않은 구독 대상입니다.");
     }
 }


### PR DESCRIPTION
### 관련 이슈
- Closed #54 

### 작업 내용
- 채팅 도메인 엔티티 및 기본 리포지토리 구현
- 멘토링 승인 시 채팅방 생성 연동
- 채팅방 목록 및 상세 조회 API 구현
- 채팅 메시지 조회 및 전송 API 구현
- 채팅 읽음 처리 및 종료 요청 API 구현
- 채팅 종료 승인 및 OB 일정 수정 API 구현
- WebSocket 및 실시간 이벤트 구현

### 상세 변경 사항
- `chat` 도메인을 새로 추가하고 `ChatRoom`, `ChatMessage` 엔티티를 구현했습니다.
- `ChatRoomStatus`, `ChatCloseRequester`, `ChatMessageStatus` enum을 추가했습니다.
- `ChatRoomRepository`, `ChatMessageRepository`를 추가했습니다.
- `MypageService.approveOBMentoringRequest()`에 채팅방 생성 로직을 연동했습니다.
- `GET /api/chat/rooms` 추가
- `GET /api/chat/rooms/{roomId}` 추가
- `GET /api/chat/rooms/{roomId}/messages` 추가
- `POST /api/chat/rooms/{roomId}/messages` 추가
- `POST /api/chat/rooms/{roomId}/read` 추가
- `POST /api/chat/rooms/{roomId}/close-request` 추가
- `POST /api/chat/rooms/{roomId}/close-approve` 추가
- `PUT /api/chat/rooms/{roomId}/schedule` 추가
- `/ws/chat` WebSocket endpoint를 추가했습니다.
- STOMP 기반 pub/sub 구조와 채팅 이벤트 응답 DTO를 추가했습니다.

### 구현 포인트
- 멘토링 신청 1건당 채팅방 1개가 생성되도록 모델링해, 승인 트랜잭션 내부에서 멘토링 상태 변경과 채팅방 생성을 함께 처리했습니다.
- 채팅 메시지는 커서 기반 페이지네이션으로 구현해 최초 50건 조회, 이후 이전 메시지 추가 조회가 가능하도록 구성했습니다.
- 채팅방 목록 조회에서는 미읽음 수를 방별 개별 조회하지 않고, room id 기준 그룹 집계 쿼리로 한 번에 조회하도록 구현했습니다.
- 읽음 처리는 개별 메시지 순회가 아니라 벌크 업데이트로 처리해 입장 시 전체 읽음 처리 요구사항에 맞췄습니다.
- 종료 요청/승인 흐름은 채팅방 락 기반으로 처리해 상태 경쟁 상황에서도 `closeRequester`, `ChatRoomStatus`, `MentoringApplication.status`가 함께 정합성 있게 변경되도록 구성했습니다.
- 종료 승인 시 `MentoringApplication -> COMPLETED`, `ChatRoom -> READ_ONLY`를 한 트랜잭션에서 반영했습니다.
- 일정 수정은 OB 권한뿐 아니라 해당 채팅방의 멘토 참여자인지까지 함께 검증하도록 구현했습니다.
- WebSocket은 현재 프로젝트 JWT 인증 구조와 맞춰 STOMP `CONNECT` 시 `Authorization` 헤더 기반 인증을 수행하도록 구성했습니다.
- REST와 WebSocket이 서로 다른 로직을 갖지 않도록, 둘 다 동일한 `ChatService`를 타고 서비스 레벨에서 실시간 이벤트를 발행하도록 설계했습니다.
- 실시간 이벤트는 `MESSAGE_SENT`, `MESSAGE_READ`, `CLOSE_REQUESTED`, `CLOSE_APPROVED`, `SCHEDULE_UPDATED`, `ROOM_LIST_UPDATED`로 분리해 프론트가 필요한 화면만 갱신할 수 있도록 했습니다.

### 테스트
- `./gradlew compileJava` 성공 확인

### 참고 사항
- 현재 WebSocket 브로커는 Spring Simple Broker 기반으로 구성했습니다.
- 프론트는 STOMP 연결 시 `Authorization: Bearer {accessToken}` 헤더를 함께 전달해야 합니다.